### PR TITLE
Adds missing configuration options, updates to latest java-fedora-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,18 @@ By default, the application will look for a configuration file named `nihms-load
 The configuration file should look like this: 
 ```
 nihmsetl.data.dir=/path/to/pass/loaders/data
+nihmsetl.repository.uri=https://example:8080/fcrepo/rest/repositories/aaa/bbb/ccc
+nihmsetl.pmcurl.template=https://www.ncbi.nlm.nih.gov/pmc/articles/%s/
 pass.fedora.baseurl=http://localhost:8080/fcrepo/rest/
 pass.fedora.user=admin
 pass.fedora.password=password
 pass.elasticsearch.url=http://localhost:9200/pass/
 pass.elasticsearch.limit=200
-
 ```
 
 * `nihmsetl.data.dir` is the path that the CSV files will be read from. If a path is not defined, the app will look for a `/data` folder in the folder containing the java app.
+* `nihmsetl.repository.uri` the URI for the Repository resource in PASS that represents the PMC repository.
+* `nihmsetl.pmcurl.template` is the template URL used to construct the RepositoryCopy.accessUrl. The article PMC is passed into this URL.
 * `pass.fedora.baseurl` - Base URL for Fedora
 * `pass.fedora.user` - User name for Fedora access
 * `pass.fedora.password` - Password for Fedora access

--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>entrez-pmid-lookup</artifactId>

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-harvest-cli</artifactId>
   <packaging>jar</packaging>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>nihms-data-harvest</artifactId>

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load-cli</artifactId>
   <name>NIHMS Data Transform/Load Command Line Interface</name>

--- a/nihms-data-transform-load-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsTransformLoadApp.java
+++ b/nihms-data-transform-load-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsTransformLoadApp.java
@@ -46,7 +46,8 @@ public class NihmsTransformLoadApp {
      */
     private static final String[] SYSTEM_PROPERTIES = {"pass.fedora.user", "pass.fedora.password", 
                                                        "pass.fedora.baseurl", "pass.elasticsearch.url",
-                                                       "pass.elasticsearch.limit"};
+                                                       "pass.elasticsearch.limit","nihmsetl.repository.uri",
+                                                       "nihmsetl.pmcurl.template"};
         
     private Set<NihmsStatus> statusesToProcess;
 

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load</artifactId>
   <name>NIHMS Data Transform/Load</name>

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -48,7 +48,7 @@ public class NihmsPublicationToSubmission {
 
     private static final Logger LOG = LoggerFactory.getLogger(NihmsPublicationToSubmission.class);
     
-    private static final String PMC_URL_TEMPLATE_KEY = "pmc.url.template"; 
+    private static final String PMC_URL_TEMPLATE_KEY = "nihmsetl.pmcurl.template"; 
     private static final String PMC_URL_TEMPLATE_DEFAULT = "https://www.ncbi.nlm.nih.gov/pmc/articles/%s/";
     
     private static final String NIHMS_CSV_DATE_PATTERN = "MM/dd/yyyy";
@@ -228,7 +228,7 @@ public class NihmsPublicationToSubmission {
     private RepositoryCopy initiateNewRepositoryCopy(NihmsPublication pub, URI publicationId) {
         RepositoryCopy repositoryCopy = new RepositoryCopy();
 
-        LOG.info("NIHMS RepositoryCopy record needed for PMID \"{}\", initiating new Deposit record", pub.getPmid());
+        LOG.info("NIHMS RepositoryCopy record needed for PMID \"{}\", initiating new RepositoryCopy record", pub.getPmid());
 
         repositoryCopy.setPublication(publicationId);
         repositoryCopy.setCopyStatus(calcRepoCopyStatus(pub, null));

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -65,7 +65,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
@@ -102,7 +102,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:latest</name>
+              <name>oapass/indexer:0.0.6-2.0-SNAPSHOT</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-integration</artifactId>
   <name>NIHMS ELT Integration Tests</name>

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-etl-model</artifactId>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-util</artifactId>
   <name>NIHMS ETL Utilities</name>

--- a/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ConfigUtil.java
+++ b/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ConfigUtil.java
@@ -31,7 +31,7 @@ import java.util.Properties;
  */
 public class ConfigUtil {
 
-    private static final String NIHMS_REPOSITORY_URI_KEY = "nihms.repository.uri"; 
+    private static final String NIHMS_REPOSITORY_URI_KEY = "nihmsetl.repository.uri"; 
     private static final String NIHMS_REPOSITORY_URI_DEFAULT = "https://example.com/fedora/repositories/1";
                 
     /** 

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-pass-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <org-json.version>20180130</org-json.version>
     <commons-csv.version>1.5</commons-csv.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <pass-client.version>0.2.0-SNAPSHOT</pass-client.version>
+    <pass-client.version>0.3.0-SNAPSHOT</pass-client.version>
     <logback.version>1.2.3</logback.version>
     <selenium.version>3.11.0</selenium.version>
     <args4j.version>2.33</args4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>


### PR DESCRIPTION
Several configuration options were missing from being configurable via the properties file. Namely `nihmsetl.repository.uri` and `nihmsetl.pmcurl.template`. These were renamed to be consistent with other properties, and added to the list of properties that can be set using the configuration file.

Also updated to use `0.3.0-SNAPSHOT` of `java-fedora-client`.