### PR TITLE
Make geckodriver exit command use proper file name and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The NIHMS Data Harvest CLI uses Selenium with the FireFox drivers to log in and 
 ### Pre-requisites
 The following are required to run this tool:
 * Download the latest nihms-data-harvest-cli-{version}-shaded.jar from the [releases page](https://github.com/OA-PASS/nihms-submission-etl/releases) and place in a folder on the machine where the application will run.
-* Install FireFox on the machine that will run the harvester. You do not need to be able to open the browser, the application will run in "headless" mode.
+* Install FireFox (version 55 or later) on the machine that will run the harvester. You do not need to be able to open the browser, the application will run in "headless" mode.
 * Download the [geckodriver](https://github.com/mozilla/geckodriver/releases/tag/v0.20.1) (v0.20.1 has been tested) unzip the folder, locate the geckodriver executable and move it to a convenient location.
 * Get an account for the NIH PACM website
 * Create a data folder that files will be downloaded to.

--- a/nihms-data-harvest-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsHarvesterApp.java
+++ b/nihms-data-harvest-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsHarvesterApp.java
@@ -83,7 +83,7 @@ public class NihmsHarvesterApp {
         } else {
             LOG.warn("Could not find a readable config file at path {}, will use current system and environment variables for configuration. "
                     + "To use a config file, create a file named \"{}\" in the app's folder or provide a valid path "
-                    + "using the \"nihms.config.filepath\" environment variable.", configFile.getAbsolutePath(), DEFAULT_CONFIG_FILENAME);
+                    + "using the \"{}\" environment variable.", configFile.getAbsolutePath(), DEFAULT_CONFIG_FILENAME, NIHMS_CONFIG_FILEPATH_PROPKEY);
         }
         
         NihmsHarvester harvester = new NihmsHarvester();

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
@@ -194,25 +194,31 @@ public class NihmsHarvester {
             if (statusesToDownload.contains(NihmsStatus.COMPLIANT)) {
                 driver.findElement(By.xpath(GUI_COMPLIANT_LINK_XPATH)).click();     
                 LOG.info("Goto compliant list");
+                Thread.sleep(2000);     
                 driver.findElement(By.linkText(GUI_DOWNLOAD_LINKTEXT)).click(); 
                 String newfile = pollAndRename(COMPLIANT_FILE_PREFIX, NihmsStatus.COMPLIANT);    
-                LOG.info("Downloaded compliant publications as file " + newfile);       
+                LOG.info("Downloaded and saved compliant publications as file " + newfile);     
+                Thread.sleep(2000);     
             }        
             
             if (statusesToDownload.contains(NihmsStatus.NON_COMPLIANT)) {
                 driver.findElement(By.xpath(GUI_NONCOMPLIANT_LINK_XPATH)).click();     
                 LOG.info("Goto non-compliant list");
+                Thread.sleep(2000);     
                 driver.findElement(By.linkText(GUI_DOWNLOAD_LINKTEXT)).click(); 
                 String newfile = pollAndRename(NONCOMPLIANT_FILE_PREFIX, NihmsStatus.NON_COMPLIANT);
                 LOG.info("Downloaded and saved non-compliant publications as file " + newfile);       
+                Thread.sleep(2000);       
             }
             
             if (statusesToDownload.contains(NihmsStatus.IN_PROCESS)) {
                 driver.findElement(By.xpath(GUI_INPROCESS_LINK_XPATH)).click();     
                 LOG.info("Goto in-process list");
+                Thread.sleep(2000);     
                 driver.findElement(By.linkText(GUI_DOWNLOAD_LINKTEXT)).click();  
                 String newfile = pollAndRename(INPROCESS_FILE_PREFIX, NihmsStatus.IN_PROCESS);
-                LOG.info("Downloaded and saved in-process publications as file " + newfile);       
+                LOG.info("Downloaded and saved in-process publications as file " + newfile);  
+                Thread.sleep(2000);        
             }
 
             //logout
@@ -245,11 +251,12 @@ public class NihmsHarvester {
         return (nullOrEmpty(startDate) || startDate.matches("^(0?[1-9]|1[012])-(\\d{4})$"));
     }
     
-    private String pollAndRename(String prefix, NihmsStatus status) {
+    private String pollAndRename(String prefix, NihmsStatus status) throws InterruptedException {
         File newfile = FileWatcher.getNewFile(downloadDirectoryPath, prefix, ".csv");
         LOG.info("New file downloaded: " + newfile.getAbsolutePath());
         String newFilePath = null;
         if (newfile!=null) {
+            Thread.sleep(2000);     
             DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyyMMddHHmmss");
             String timeStamp = fmt.print(new DateTime());
             newFilePath = downloadDirectoryPath.toString() + "/" + status.toString() + "_nihmspubs_" + timeStamp + ".csv";

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
@@ -221,13 +221,18 @@ public class NihmsHarvester {
         } catch (Exception ex) {
             throw new RuntimeException("An error occurred while downloading the NIHMS files.", ex);
         } finally {
-            if (driver!=null) {
-                driver.quit();
+            try {
+                if (driver!=null) {
+                    driver.quit();
+                } 
+            } catch (Exception ex) {
+                LOG.warn("Could not quit driver. Webdriver may still be running and require manual cleanup.");
             }
             try {
-                Runtime.getRuntime().exec("taskkill /F /IM geckodriver.exe /T");
+                String path = new File(NihmsHarvesterConfig.getGeckoDriverPath()).getName();
+                Runtime.getRuntime().exec("taskkill /F /IM " + path + " /T");
             } catch (Exception ex) {
-                //do nothing
+                LOG.warn("Could not clean up geckodriver task. Webdriver may still be running and require manual cleanup.");
             }
         }
     }


### PR DESCRIPTION
* geckodriver's name was hardcoded to geckodriver.exe, which is not always accurate. This changes it to take driver name from configuration path. 
* Added some pauses after seeing download issues that seemed to be to do with click being initiated too quickly after the page loads using Selenium
* Fixed the LOG message about configuration file to show correct property name
* Documented Firefox version number restriction in README.md