### PR TITLE
Handle multiple matches for Grant.awardNumber and increment version [WIP]

### DIFF
--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>entrez-pmid-lookup</artifactId>

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-harvest-cli</artifactId>
   <packaging>jar</packaging>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nihms-data-harvest</artifactId>

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load-cli</artifactId>
   <name>NIHMS Data Transform/Load Command Line Interface</name>

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load</artifactId>
   <name>NIHMS Data Transform/Load</name>

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -118,7 +118,7 @@ public class NihmsPublicationToSubmission {
     public SubmissionDTO transform(NihmsPublication pub) {
         
         //matching grant uri is a requirement for all nihms submissions
-        Grant grant = clientService.findGrantByAwardNumber(pub.getGrantNumber());
+        Grant grant = clientService.findMostRecentGrantByAwardNumber(pub.getGrantNumber());
         if (grant==null) {
             throw new RuntimeException(String.format("No Grant matching award number \"%s\" was found. Cannot process submission with pmid %s", pub.getGrantNumber(), pub.getPmid()));
         }

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
@@ -110,7 +110,7 @@ public class SubmissionTransformerTest {
         Grant grant = newTestGrant();
         
         //Mocking that we have a valid grant URI, PMID, and DOI to use.
-        when(clientServiceMock.findGrantByAwardNumber(awardNumber)).thenReturn(grant);
+        when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
         when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(null);
         when(clientServiceMock.findJournalByIssn(issn)).thenReturn(new URI(sJournalUri));
         
@@ -144,7 +144,7 @@ public class SubmissionTransformerTest {
         pub.setTaggingCompleteDate(depositDate);
 
         Grant grant = newTestGrant();
-        when(clientServiceMock.findGrantByAwardNumber(awardNumber)).thenReturn(grant);
+        when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
         when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(null);
         when(clientServiceMock.findJournalByIssn(issn)).thenReturn(new URI(sJournalUri));
         when(pmidLookupMock.retrievePubMedRecord(pmid)).thenReturn(pubMedRecordMock);
@@ -189,7 +189,7 @@ public class SubmissionTransformerTest {
         submissions.add(submission);
         
         Grant grant = newTestGrant();
-        when(clientServiceMock.findGrantByAwardNumber(awardNumber)).thenReturn(grant);
+        when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
         
         when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(publication);
         when(clientServiceMock.findSubmissionsByPublicationAndUserId(publication.getId(), grant.getPi())).thenReturn(submissions);
@@ -237,7 +237,7 @@ public class SubmissionTransformerTest {
         submissions.add(submission);
         
         Grant grant = newTestGrant();
-        when(clientServiceMock.findGrantByAwardNumber(awardNumber)).thenReturn(grant);
+        when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
         
         when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(publication);
         when(clientServiceMock.findSubmissionsByPublicationAndUserId(publication.getId(), grant.getPi())).thenReturn(submissions);
@@ -268,7 +268,7 @@ public class SubmissionTransformerTest {
     @Test
     public void testTransformNoMatchingGrantThrowsException() {
 
-        when(clientServiceMock.findGrantByAwardNumber(Mockito.anyObject())).thenReturn(null);
+        when(clientServiceMock.findMostRecentGrantByAwardNumber(Mockito.anyObject())).thenReturn(null);
         expectedEx.expect(RuntimeException.class);
         expectedEx.expectMessage("No Grant matching award number");
         

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-integration</artifactId>
   <name>NIHMS ELT Integration Tests</name>

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-etl-model</artifactId>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-util</artifactId>
   <name>NIHMS ETL Utilities</name>

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-pass-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>


### PR DESCRIPTION
This change deals with the discovery that there can be multiple Grants for a given awardNumber. Previously there was an assumption there would only be one. The change retrieves the matching Grants and then selects the one with the most recent `Grant.startDate`. 