### PR TITLE
Improve performance, remove DOI prefix, format ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following are required to run this tool:
 * Create a data folder that files will be downloaded to.
 
 ### Data Harvest Configuration
-There are several ways to configure the Data Harvest CLI. You can use a configuration file, environment variables, system variables, or a combination of these. The configuration file will set system properties. In the absence of a config file, system properties will be used, and in the absence of those, environment variables will be used.
+There are several ways to configure the Data Harvest CLI. You can use a configuration file, environment variables, system variables, or a combination of these. The configuration file will set system properties. In the absence of a config file, system properties will be used, and in the absence of those, environment variables will be used. Note that to use environment variables, the system property name must be converted to upper case, and the periods replaced with underscores. For example, to define `nihmsetl.data.dir` as an environment variable, use `NIHMSETL_DATA_DIR` instead.
 
 By default, the application will look for a configuration file named `nihms-harvest.properties` in the folder containing the java application. You can override the location of the properties file by defining an environment variable for `nihmsetl.harvester.configfile` e.g. 
 ```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ By default, the application will look for a configuration file named `nihms-load
 The configuration file should look like this: 
 ```
 nihmsetl.data.dir=/path/to/pass/loaders/data
+nihmsetl.loader.cachepath=/path/to/pass/loaders/cache/compliant-cache.data
 nihmsetl.repository.uri=https://example:8080/fcrepo/rest/repositories/aaa/bbb/ccc
 nihmsetl.pmcurl.template=https://www.ncbi.nlm.nih.gov/pmc/articles/%s/
 pass.fedora.baseurl=http://localhost:8080/fcrepo/rest/
@@ -78,6 +79,7 @@ pass.elasticsearch.limit=200
 ```
 
 * `nihmsetl.data.dir` is the path that the CSV files will be read from. If a path is not defined, the app will look for a `/data` folder in the folder containing the java app.
+* `nihmsetl.loader.cachepath` designates a path to a file that will be used to store a cache of completed compliant data so that it is not reprocessed. Note that this file can be deleted to force a complete recheck of the data.  If a path is not defined, this will default to a file at `/cache/compliant-cache.data` in the folder containing the java app.
 * `nihmsetl.repository.uri` the URI for the Repository resource in PASS that represents the PMC repository.
 * `nihmsetl.pmcurl.template` is the template URL used to construct the RepositoryCopy.accessUrl. The article PMC is passed into this URL.
 * `pass.fedora.baseurl` - Base URL for Fedora

--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>entrez-pmid-lookup</artifactId>

--- a/entrez-pmid-lookup/src/main/java/org/dataconservancy/pass/entrez/PubMedEntrezRecord.java
+++ b/entrez-pmid-lookup/src/main/java/org/dataconservancy/pass/entrez/PubMedEntrezRecord.java
@@ -36,7 +36,6 @@ public class PubMedEntrezRecord {
     private static final String JSON_ISSUE_KEY = "issue";    
     private static final String JSON_ISSN_KEY = "issn";   
     private static final String JSON_ESSN_KEY = "essn";   
-    private static final String DOI_PREFIX = "https://doi.org/";
     private static final String VALID_DOI_CONTAINS = "10.";
     
     /**
@@ -71,7 +70,6 @@ public class PubMedEntrezRecord {
                 doi = id.getString(JSON_IDVALUE_KEY);
                 if (doi!=null && doi.length()>0 && doi.contains(VALID_DOI_CONTAINS)) {
                     doi = doi.trim();
-                    doi = DOI_PREFIX + doi;
                 }
             }                    
         }        

--- a/entrez-pmid-lookup/src/test/java/org/dataconservancy/pass/entrez/EntrezPmidLookupTest.java
+++ b/entrez-pmid-lookup/src/test/java/org/dataconservancy/pass/entrez/EntrezPmidLookupTest.java
@@ -45,7 +45,7 @@ public class EntrezPmidLookupTest {
         PmidLookup pmidLookup = new PmidLookup();
         String pmid = "29249144";
         PubMedEntrezRecord record = pmidLookup.retrievePubMedRecord(pmid);        
-        assertEquals("https://doi.org/10.1021/acs.jproteome.7b00775", record.getDoi());
+        assertEquals("10.1021/acs.jproteome.7b00775", record.getDoi());
         
     }
     

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-harvest-cli</artifactId>
   <packaging>jar</packaging>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nihms-data-harvest</artifactId>

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load-cli</artifactId>
   <name>NIHMS Data Transform/Load Command Line Interface</name>

--- a/nihms-data-transform-load-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsTransformLoadApp.java
+++ b/nihms-data-transform-load-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsTransformLoadApp.java
@@ -47,7 +47,7 @@ public class NihmsTransformLoadApp {
     private static final String[] SYSTEM_PROPERTIES = {"pass.fedora.user", "pass.fedora.password", 
                                                        "pass.fedora.baseurl", "pass.elasticsearch.url",
                                                        "pass.elasticsearch.limit","nihmsetl.repository.uri",
-                                                       "nihmsetl.pmcurl.template"};
+                                                       "nihmsetl.pmcurl.template", "nihmsetl.loader.cachepath"};
         
     private Set<NihmsStatus> statusesToProcess;
 

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load</artifactId>
   <name>NIHMS Data Transform/Load</name>

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/CompletedPublicationsCache.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/CompletedPublicationsCache.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.loader.nihms;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
+
+import org.dataconservancy.pass.loader.nihms.util.ConfigUtil;
+import org.dataconservancy.pass.loader.nihms.util.FileUtil;
+
+import static org.dataconservancy.pass.loader.nihms.util.ProcessingUtil.nullOrEmpty;
+
+/**
+ * This controls a simple local text file containing a list of compliant "pmid|grantNumber" combinations
+ * that are considered DONE and therefore require no re-processing. Only compliant records with a PMCID already
+ * assigned should be added to this list. The list is used as a lookup during processing to avoid the excessive 
+ * database interactions that are required to re-process completed nihms data. 
+ * 
+ * @author Karen Hanson
+ */
+public class CompletedPublicationsCache {    
+
+    private static final String CACHEPATH_KEY = "nihmsetl.loader.cachepath";
+    
+    private static final String CACHEPATH_DEFAULT = "/cache/compliant-cache.data";
+        
+    private File cacheFile = null;
+    
+    private Set<String> processed;
+    
+    /**
+     * Check for cache file and load data into memory
+     */
+    @SuppressWarnings("unchecked")
+    public CompletedPublicationsCache() {
+        String sCacheFile = ConfigUtil.getSystemProperty(CACHEPATH_KEY, FileUtil.getCurrentDirectory() + CACHEPATH_DEFAULT);
+        try {
+            File cacheFile = new File(sCacheFile);
+            if (!cacheFile.exists()) {
+                cacheFile.getParentFile().mkdirs();
+                cacheFile.createNewFile();
+            }
+            this.cacheFile = cacheFile;
+            // read in cached values
+            processed = new HashSet<String>(FileUtils.readLines(cacheFile));
+        } catch (Exception ex) {
+            throw new RuntimeException("Could not create cache file to hold compliant records at path " + sCacheFile, ex);
+        }
+    }
+    
+    /**
+     * Check if file contains record
+     * @param pmid
+     * @param awardNumber
+     * @return
+     */
+    public boolean contains(String pmid, String awardNumber) {
+        if (!nullOrEmpty(pmid) && !nullOrEmpty(awardNumber)) {
+            String cachevalue = pmid + "|" + awardNumber;
+            return processed.contains(cachevalue);
+            
+        }
+        return false;
+    }
+    
+    /**
+     * Add a record to the cache file
+     * @param pmid
+     * @param awardNumber
+     */
+    public void add(String pmid, String awardNumber) {
+        if (!nullOrEmpty(pmid) && !nullOrEmpty(awardNumber) 
+                && !contains(pmid, awardNumber)) {
+            String cachevalue = pmid + "|" + awardNumber;
+            try (PrintWriter output = new PrintWriter(new FileWriter(cacheFile, true))){
+                processed.add(cachevalue);
+                output.println(cachevalue);
+            } catch (Exception ex) {
+                throw new RuntimeException("Problem writing cachevalue: " + cachevalue + " to cache");
+            }
+        }
+    }
+    
+}

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsCsvProcessor.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsCsvProcessor.java
@@ -66,6 +66,7 @@ public class NihmsCsvProcessor {
     private static final String ARTICLETITLE_HEADING = "Article Title";
     private static final Integer ARTICLETITLE_COLNUM = 10;
     
+    
     /**
      * Lists expected headers and their column number to support header validation
      */
@@ -152,10 +153,10 @@ public class NihmsCsvProcessor {
             pub = new NihmsPublication(status, row.get(PMID_COLNUM), row.get(GRANTID_COLNUM), row.get(NIHMSID_COLNUM), 
                                          row.get(PMCID_COLNUM), row.get(FILEDEPOSIT_COLNUM), row.get(INITIALAPPROVAL_COLNUM), 
                                          row.get(TAGGINGCOMPLETE_COLNUM), row.get(FINALAPPROVAL_COLNUM), row.get(ARTICLETITLE_COLNUM));
-
+            
             LOG.info("NIHMS record pmid={} is being processed", pub.getPmid());
             pubConsumer.accept(pub);  
-            LOG.info("NIHMS record pmid={} was transformed and loaded successfully", pub.getPmid());                
+            LOG.info("NIHMS record pmid={} was processed successfully", pub.getPmid()); 
         }
         catch (Exception ex) {
             failCount = failCount + 1;

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -239,7 +239,9 @@ public class NihmsPublicationToSubmission {
         if (publicationId != null) {
             repoCopy = clientService.findNihmsRepositoryCopyForPubId(publicationId);
         }
-        if (repoCopy==null && !nullOrEmpty(pub.getNihmsId())) { //only create if there is at least a nihms ID indicating something is started
+        if (repoCopy==null 
+                && (!nullOrEmpty(pub.getNihmsId()) || !nullOrEmpty(pub.getPmcId()))) { 
+             //only create if there is at least a nihms ID indicating something is started
             repoCopy = initiateNewRepositoryCopy(pub, publicationId);
             submissionDTO.setUpdateRepositoryCopy(true);
         } else if (repoCopy != null) {

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -77,6 +77,12 @@ public class NihmsPublicationToSubmission {
     private String pmcUrlTemplate;
     
     /**
+     * Captures information needed to generate Submission using Submission Loader.
+     */
+    private SubmissionDTO submissionDTO;
+    
+    
+    /**
      * Constructor uses defaults for client service and pmid lookup
      * @param clientService
      */
@@ -88,6 +94,7 @@ public class NihmsPublicationToSubmission {
     
     /**
      * Constructor initiates with the required NIHMS Client Service and PMID lookup
+     * Useful to pass in an existing clientService to reuse cache 
      * @param clientService
      */
     public NihmsPublicationToSubmission(NihmsPassClientService clientService, PmidLookup pmidLookup) {
@@ -116,7 +123,7 @@ public class NihmsPublicationToSubmission {
      * @return
      */
     public SubmissionDTO transform(NihmsPublication pub) {
-        
+                
         //matching grant uri is a requirement for all nihms submissions
         Grant grant = clientService.findMostRecentGrantByAwardNumber(pub.getGrantNumber());
         if (grant==null) {
@@ -124,7 +131,7 @@ public class NihmsPublicationToSubmission {
         }
         
         //this stage will be all about building up the DTO
-        SubmissionDTO submissionDTO = new SubmissionDTO();
+        submissionDTO = new SubmissionDTO();
         submissionDTO.setGrantId(grant.getId());
         
         Publication publication = retrieveOrCreatePublication(pub);
@@ -151,22 +158,36 @@ public class NihmsPublicationToSubmission {
         //use pmid to get additional metadata from Entrez. Need this for DOI, maybe other fields too
         String pmid = nihmsPub.getPmid();
         String doi = null;
+        PubMedEntrezRecord pubmedRecord = null;
 
-        //NOTE: if this returns null, the request succeeded, but Entrez could not match the record so we should proceed without one.
-        //A RuntimeException would be thrown and the transform would fail if there was e.g. a config or connection problem.
-        PubMedEntrezRecord pubmedRecord = pmidLookup.retrievePubMedRecord(pmid);
-        if (pubmedRecord != null) {
-            doi = pubmedRecord.getDoi();
-        } 
-        Publication publication = clientService.findPublicationById(pmid, doi);
-        if (publication==null){
+        Publication publication = clientService.findPublicationByPmid(pmid);
+
+        // get missing information from Entrez, if necessary
+        if (publication==null || nullOrEmpty(publication.getDoi())) {
+            //NOTE: if this returns null, the request succeeded, but Entrez could not match the record so we should proceed without one.
+            //A RuntimeException would be thrown and the transform would fail if there was e.g. a config or connection problem.
+            pubmedRecord = pmidLookup.retrievePubMedRecord(pmid);
+            if (pubmedRecord != null) {
+                doi = pubmedRecord.getDoi();
+            } 
+        }
+
+        // if there is no match pmid in database, check if there is a match for doi
+        if (publication==null && !nullOrEmpty(doi)) {
+            publication = clientService.findPublicationByDoi(doi, pmid);
+        }
+        
+        if (publication==null) {
             publication = initiateNewPublication(nihmsPub, pubmedRecord);
+            submissionDTO.setUpdatePublication(true);
         }  else {
             if (nullOrEmpty(publication.getDoi()) && !nullOrEmpty(doi)) {
                 publication.setDoi(doi);
+                submissionDTO.setUpdatePublication(true);
             }
             if (nullOrEmpty(publication.getPmid())) {
                 publication.setPmid(pmid);
+                submissionDTO.setUpdatePublication(true);
             }
         }
         
@@ -220,6 +241,30 @@ public class NihmsPublicationToSubmission {
         }
         if (repoCopy==null && !nullOrEmpty(pub.getNihmsId())) { //only create if there is at least a nihms ID indicating something is started
             repoCopy = initiateNewRepositoryCopy(pub, publicationId);
+            submissionDTO.setUpdateRepositoryCopy(true);
+        } else if (repoCopy != null) {
+            //check external ids are updated
+            List<String> externalIds = repoCopy.getExternalIds();
+            String pmcId = pub.getPmcId();
+            if (!nullOrEmpty(pmcId) && !externalIds.contains(pmcId)){
+                externalIds.add(pmcId);    
+                repoCopy.setAccessUrl(createAccessUrl(pmcId));  
+                submissionDTO.setUpdateRepositoryCopy(true);      
+            }
+            String nihmsId = pub.getNihmsId();
+            if (!nullOrEmpty(nihmsId) && !externalIds.contains(nihmsId)) {
+                externalIds.add(nihmsId);   
+                submissionDTO.setUpdateRepositoryCopy(true);         
+            }
+            repoCopy.setExternalIds(externalIds);
+            
+            //check if copystatus changed
+            CopyStatus copyStatus = repoCopy.getCopyStatus();
+            CopyStatus newCopyStatus = calcRepoCopyStatus(pub, copyStatus);
+            if (!copyStatus.equals(newCopyStatus)) {
+                repoCopy.setCopyStatus(newCopyStatus);
+                submissionDTO.setUpdateRepositoryCopy(true);        
+            }
         }
         return repoCopy;
     }
@@ -293,17 +338,25 @@ public class NihmsPublicationToSubmission {
                 // to add repository to instead of creating a new one. First one found will do
                 if (submission == null) {
                     submission = submissions.stream().filter(s -> !s.getSubmitted()).findFirst().orElse(null);
+                    if (submission != null) {
+                        List<URI> repositories = submission.getRepositories();
+                        repositories.add(nihmsRepositoryUri);
+                        submission.setRepositories(repositories);
+                        submissionDTO.setUpdateSubmission(true);   
+                    }
                 }
                 
             } 
         }
         
         if (submission==null) {
-            submission = initiateNewSubmission(grant, publicationUri);    
+            submission = initiateNewSubmission(grant, publicationUri); 
+            submissionDTO.setUpdateSubmission(true);   
         }
         
-        // if we have a repository copy, but the submission is not marked as submitted, set it as submitted and use file deposit date
-        // when a submission is set to submitted by this transform process, it becomes Source.OTHER regardless of where it started
+        // if we have a repository copy, and there is only one repository listed on the submission (would be the nihsm repo)
+        // but the submission is not marked as submitted, set it as submitted and use file deposit date as submitted date
+        // Wwhen a submission is set to submitted by this transform process, it becomes Source.OTHER regardless of where it started
         if (submission.getRepositories().size()==1
                 && hasRepoCopy 
                 && !submission.getSubmitted()) {
@@ -313,6 +366,7 @@ public class NihmsPublicationToSubmission {
             if (!nullOrEmpty(depositedDate)) {
                 submission.setSubmittedDate(formatDate(depositedDate, NIHMS_CSV_DATE_PATTERN));
             }
+            submissionDTO.setUpdateSubmission(true);   
         }
 
         // finally, make sure grant is in the list of the chosen submission
@@ -320,6 +374,7 @@ public class NihmsPublicationToSubmission {
         if (!grants.contains(grantId)) {
             grants.add(grantId);
             submission.setGrants(grants);
+            submissionDTO.setUpdateSubmission(true);   
         }
                 
         return submission;

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionDTO.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionDTO.java
@@ -147,6 +147,14 @@ public class SubmissionDTO {
 
     
     /**
+     * @return updateRepositoryCopy true if update should be performed
+     */
+    public boolean doUpdate() {
+        return (updateRepositoryCopy || updateSubmission  || updatePublication);
+    }
+
+    
+    /**
      * @param updateRepositoryCopy the updateRepositoryCopy to set
      */
     public void setUpdateRepositoryCopy(boolean updateRepositoryCopy) {

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionDTO.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionDTO.java
@@ -34,6 +34,12 @@ public class SubmissionDTO {
         
     private RepositoryCopy repositoryCopy = null;
     
+    private boolean updatePublication = false;
+    
+    private boolean updateSubmission = false;
+    
+    private boolean updateRepositoryCopy = false;
+    
     private URI grantId = null;
 
     
@@ -97,6 +103,54 @@ public class SubmissionDTO {
      */
     public void setGrantId(URI grantId) {
         this.grantId = grantId;
+    }
+
+    
+    /**
+     * @return updatePublication true if update should be performed
+     */
+    public boolean doUpdatePublication() {
+        return updatePublication;
+    }
+
+    
+    /**
+     * @param updatePublication the updatePublication to set
+     */
+    public void setUpdatePublication(boolean updatePublication) {
+        this.updatePublication = updatePublication;
+    }
+
+    
+    /**
+     * @return updateSubmission true if update should be performed
+     */
+    public boolean doUpdateSubmission() {
+        return updateSubmission;
+    }
+
+    
+    /**
+     * @param updateSubmission the updateSubmission to set
+     */
+    public void setUpdateSubmission(boolean updateSubmission) {
+        this.updateSubmission = updateSubmission;
+    }
+
+    
+    /**
+     * @return updateRepositoryCopy true if update should be performed
+     */
+    public boolean doUpdateRepositoryCopy() {
+        return updateRepositoryCopy;
+    }
+
+    
+    /**
+     * @param updateRepositoryCopy the updateRepositoryCopy to set
+     */
+    public void setUpdateRepositoryCopy(boolean updateRepositoryCopy) {
+        this.updateRepositoryCopy = updateRepositoryCopy;
     }
     
 }

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
@@ -57,7 +57,6 @@ public class SubmissionLoader {
      * by implementing retries, failing gracefully etc.
      * @param dto
      */
-    //TODO: need to add the code for dealing with conflicts in Fedora once that functionality is added to the pass-client
     public void load(SubmissionDTO dto) {
         if (dto==null || dto.getSubmission()==null) {
             throw new RuntimeException("A null Submission object was passed to the loader.");
@@ -70,7 +69,7 @@ public class SubmissionLoader {
         if (publicationUri==null) {
             publicationUri = clientService.createPublication(publication);
             publication.setId(publicationUri);
-        } else {
+        } else if (dto.doUpdatePublication()) {
             clientService.updatePublication(publication);
         }
 
@@ -80,7 +79,7 @@ public class SubmissionLoader {
             submission.setPublication(publicationUri);
             submissionUri = clientService.createSubmission(submission);
             submission.setId(submissionUri);
-        } else {
+        } else if (dto.doUpdateSubmission()) {
             clientService.updateSubmission(submission);
         }
 
@@ -91,7 +90,7 @@ public class SubmissionLoader {
                 repositoryCopy.setPublication(publicationUri);
                 clientService.createRepositoryCopy(repositoryCopy);
                 repositoryCopy.setId(repositoryCopyUri);
-            } else {
+            } else if (dto.doUpdateRepositoryCopy()){
                 clientService.updateRepositoryCopy(repositoryCopy);
             }
             

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/CompletedPublicationsCacheTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/CompletedPublicationsCacheTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.loader.nihms;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.dataconservancy.pass.loader.nihms.util.FileUtil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests CompletedPublicationsCache class
+ * @author Karen Hanson
+ */
+public class CompletedPublicationsCacheTest {
+
+    
+    String cachepath = null;
+
+    @Before
+    public void startup() {
+        cachepath = FileUtil.getCurrentDirectory() +"/cache/compliant-cache.data";
+        System.setProperty("nihmsetl.loader.cachepath", cachepath);
+    }
+    
+    @After
+    public void cleanup() {
+        File cachefile = new File(cachepath);
+        if (cachefile.exists()) {
+            cachefile.delete();
+        }
+    }    
+
+    /**
+     * Makes sure cache contains items after you add them
+     * Also ensure that when you create a new cache object 
+     * that it reads in the existing values correctly
+     */
+    @Test
+    public void testAddThenFindMatch() {
+        CompletedPublicationsCache cache = new CompletedPublicationsCache();
+        String pmid1 = "123456";
+        String pmid2 = "987654";
+        String awardNum1 = "AB1 FI12345";
+        String awardNum2 = "AB2 RF21355";
+        
+        assertFalse(cache.contains(pmid1, awardNum1));
+        assertFalse(cache.contains(pmid2, awardNum2));
+        
+        cache.add(pmid1, awardNum1);
+        cache.add(pmid2, awardNum2);
+        
+        assertTrue(cache.contains(pmid1, awardNum1));
+        assertTrue(cache.contains(pmid2, awardNum2));
+        
+        cache = null;
+        //recreate cache object and check we can still find the cached items
+        CompletedPublicationsCache cache2 = new CompletedPublicationsCache();
+        assertTrue(cache2.contains(pmid1, awardNum1));
+        assertTrue(cache2.contains(pmid2, awardNum2));        
+    }
+
+    /**
+     * Makes sure adding duplicate data does not add rows to the cache file
+     * @throws Exception 
+     */
+    @Test
+    public void testDoesNotAddDuplicates() throws Exception {
+        CompletedPublicationsCache cache = new CompletedPublicationsCache();
+        String pmid1 = "123456";
+        String pmid2 = "987654";
+        String awardNum1 = "AB1 FI12345";
+        String awardNum2 = "AB2 RF21355";
+        
+        assertFalse(cache.contains(pmid1, awardNum1));
+        assertFalse(cache.contains(pmid2, awardNum2));
+        
+        cache.add(pmid1, awardNum1);
+        cache.add(pmid2, awardNum2);
+        cache.add(pmid1, awardNum1);
+        cache.add(pmid2, awardNum2);
+        cache.add(pmid1, awardNum1);
+        cache.add(pmid2, awardNum2);
+        
+        assertTrue(cache.contains(pmid1, awardNum1));
+        assertTrue(cache.contains(pmid2, awardNum2));
+
+        @SuppressWarnings("unchecked")
+        List<String> processed = new ArrayList<String>(FileUtils.readLines(new File(cachepath)));
+        assertEquals(2, processed.size());
+    }
+    
+    
+    
+}

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/NihmsCsvProcessorTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/NihmsCsvProcessorTest.java
@@ -15,6 +15,8 @@
  */
 package org.dataconservancy.pass.loader.nihms;
 
+import java.io.File;
+
 import java.net.URISyntaxException;
 
 import java.nio.file.Path;
@@ -22,10 +24,13 @@ import java.nio.file.Paths;
 
 import java.util.function.Consumer;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.dataconservancy.pass.loader.nihms.model.NihmsPublication;
 import org.dataconservancy.pass.loader.nihms.model.NihmsStatus;
+import org.dataconservancy.pass.loader.nihms.util.FileUtil;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -40,12 +45,29 @@ public class NihmsCsvProcessorTest {
 
     private int count = 0;
     
+    String cachepath = null;
+    
+    @Before
+    public void startup() {
+        cachepath = FileUtil.getCurrentDirectory() +"/cache/compliant-cache.data";
+        System.setProperty("nihmsetl.loader.cachepath", cachepath);
+    }
+    
+    @After
+    public void cleanup() {
+        File cachefile = new File(cachepath);
+        if (cachefile.exists()) {
+            cachefile.delete();
+        }
+    }    
+
     /**
      * Check the Iterator reads in CSV
      * @throws URISyntaxException 
      */
     @Test
     public void testReadCsv() throws URISyntaxException {
+        
         Path resource = Paths.get(NihmsCsvProcessorTest.class.getResource("/compliant_NihmsData.csv").toURI());
 
         NihmsCsvProcessor processor = new NihmsCsvProcessor(resource, NihmsStatus.COMPLIANT);

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionLoaderTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionLoaderTest.java
@@ -91,7 +91,8 @@ public class SubmissionLoaderTest {
 
         when(clientServiceMock.createPublication(publication)).thenReturn(new URI(sPublicationUri));
         when(clientServiceMock.createSubmission(submission)).thenReturn(new URI(sSubmissionUri));
-        when(clientServiceMock.findPublicationById(Mockito.eq(publication.getPmid()), Mockito.any())).thenReturn(null);
+        when(clientServiceMock.findPublicationByPmid(Mockito.eq(publication.getPmid()))).thenReturn(null);
+        when(clientServiceMock.findPublicationByDoi(Mockito.any(), Mockito.eq(publication.getPmid()))).thenReturn(null);
         
         loader.load(dto);
         
@@ -118,7 +119,7 @@ public class SubmissionLoaderTest {
      * @throws Exception
      */
     @Test
-    public void testLoadUpdatePubNewSubmissionNoRepositoryCopy() throws Exception {
+    public void testLoadExistingPubNewSubmissionNoRepositoryCopy() throws Exception {
         SubmissionLoader loader = new SubmissionLoader(clientServiceMock);
         
         Publication publication = new Publication();
@@ -139,9 +140,7 @@ public class SubmissionLoaderTest {
                 
         loader.load(dto);
         
-        ArgumentCaptor<Publication> publicationCaptor = ArgumentCaptor.forClass(Publication.class);
-        verify(clientServiceMock).updatePublication(publicationCaptor.capture());
-        assertEquals(publication, publicationCaptor.getValue());
+        verify(clientServiceMock, never()).updatePublication(Mockito.any()); 
 
         ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
         verify(clientServiceMock).createSubmission(submissionCaptor.capture()); 
@@ -161,7 +160,7 @@ public class SubmissionLoaderTest {
      * @throws Exception
      */
     @Test
-    public void testLoadUpdatePubUpdateSubmissionNoRepoCopy() throws Exception {
+    public void testLoadExistingPubExistingSubmissionNoRepoCopy() throws Exception {
         
         Publication publication = new Publication();
         publication.setId(new URI(sPublicationUri));
@@ -181,15 +180,9 @@ public class SubmissionLoaderTest {
         
         loader.load(dto);
         
-        ArgumentCaptor<Publication> publicationCaptor = ArgumentCaptor.forClass(Publication.class);
-        verify(clientServiceMock).updatePublication(publicationCaptor.capture());
-        assertEquals(publication, publicationCaptor.getValue());
-
-        ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
-        verify(clientServiceMock).updateSubmission(submissionCaptor.capture()); 
-        assertEquals(submission, submissionCaptor.getValue());
-
-        //no repo copy so shouldn't touch RepositoryCopy create/update
+        //should not update anything
+        verify(clientServiceMock, never()).updatePublication(Mockito.any()); 
+        verify(clientServiceMock, never()).updateSubmission(Mockito.any()); 
         verify(clientServiceMock, never()).createRepositoryCopy(Mockito.anyObject());    
         verify(clientServiceMock, never()).updateRepositoryCopy(Mockito.anyObject());       
         verify(clientServiceMock, never()).updateDeposit(Mockito.anyObject());     
@@ -202,7 +195,7 @@ public class SubmissionLoaderTest {
      * @throws Exception
      */
     @Test
-    public void testLoadUpdatePublicationNewSubmissionNewRepoCopy() throws Exception {
+    public void testLoadExistingPublicationNewSubmissionNewRepoCopy() throws Exception {
 
         Publication publication = new Publication();
         publication.setId(new URI(sPublicationUri));
@@ -229,14 +222,12 @@ public class SubmissionLoaderTest {
         URI repositoryCopyUri = new URI(sRepositoryCopyUri);
         when(clientServiceMock.createSubmission(submission)).thenReturn(submissionUri);
         when(clientServiceMock.createRepositoryCopy(repositoryCopy)).thenReturn(repositoryCopyUri);
-        when(clientServiceMock.findPublicationById(Mockito.eq(publication.getPmid()), Mockito.any())).thenReturn(publication);
+        when(clientServiceMock.findPublicationByPmid(Mockito.eq(publication.getPmid()))).thenReturn(publication);
         
         //run it
         loader.load(dto);     
-        
-        ArgumentCaptor<Publication> publicationCaptor = ArgumentCaptor.forClass(Publication.class);
-        verify(clientServiceMock).updatePublication(publicationCaptor.capture()); 
-        assertEquals(publication, publicationCaptor.getValue());
+
+        verify(clientServiceMock, never()).updatePublication(Mockito.any()); 
 
         ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
         verify(clientServiceMock).createSubmission(submissionCaptor.capture()); 
@@ -257,7 +248,7 @@ public class SubmissionLoaderTest {
      * @throws Exception
      */
     @Test
-    public void testLoadUpdatePubUpdateSubmissionNewRepoCopy() throws Exception {
+    public void testLoadExistingPubExistingSubmissionNewRepoCopy() throws Exception {
 
         Publication publication = new Publication();
         publication.setId(new URI(sPublicationUri));
@@ -293,13 +284,9 @@ public class SubmissionLoaderTest {
         //run it
         loader.load(dto);     
         
-        ArgumentCaptor<Publication> publicationCaptor = ArgumentCaptor.forClass(Publication.class);
-        verify(clientServiceMock).updatePublication(publicationCaptor.capture()); 
-        assertEquals(publication, publicationCaptor.getValue());
+        verify(clientServiceMock, never()).updatePublication(Mockito.any()); 
 
-        ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
-        verify(clientServiceMock).updateSubmission(submissionCaptor.capture()); 
-        assertEquals(submission, submissionCaptor.getValue());
+        verify(clientServiceMock, never()).updateSubmission(Mockito.any()); 
 
         ArgumentCaptor<RepositoryCopy> repoCopyCaptor = ArgumentCaptor.forClass(RepositoryCopy.class);
         verify(clientServiceMock).createRepositoryCopy(repoCopyCaptor.capture()); 

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
@@ -111,7 +111,8 @@ public class SubmissionTransformerTest {
         
         //Mocking that we have a valid grant URI, PMID, and DOI to use.
         when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
-        when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(null);
+        when(clientServiceMock.findPublicationByPmid(pmid)).thenReturn(null);
+        when(clientServiceMock.findPublicationByDoi(doi, pmid)).thenReturn(null);
         when(clientServiceMock.findJournalByIssn(issn)).thenReturn(new URI(sJournalUri));
         
         when(pmidLookupMock.retrievePubMedRecord(Mockito.anyString())).thenReturn(pubMedRecordMock);
@@ -145,7 +146,8 @@ public class SubmissionTransformerTest {
 
         Grant grant = newTestGrant();
         when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
-        when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(null);
+        when(clientServiceMock.findPublicationByPmid(pmid)).thenReturn(null);
+        when(clientServiceMock.findPublicationByDoi(doi, pmid)).thenReturn(null);
         when(clientServiceMock.findJournalByIssn(issn)).thenReturn(new URI(sJournalUri));
         when(pmidLookupMock.retrievePubMedRecord(pmid)).thenReturn(pubMedRecordMock);
 
@@ -191,7 +193,7 @@ public class SubmissionTransformerTest {
         Grant grant = newTestGrant();
         when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
         
-        when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(publication);
+        when(clientServiceMock.findPublicationByPmid(pmid)).thenReturn(publication);
         when(clientServiceMock.findSubmissionsByPublicationAndUserId(publication.getId(), grant.getPi())).thenReturn(submissions);
         
         when(pmidLookupMock.retrievePubMedRecord(pmid)).thenReturn(pubMedRecordMock);
@@ -239,7 +241,7 @@ public class SubmissionTransformerTest {
         Grant grant = newTestGrant();
         when(clientServiceMock.findMostRecentGrantByAwardNumber(awardNumber)).thenReturn(grant);
         
-        when(clientServiceMock.findPublicationById(pmid, doi)).thenReturn(publication);
+        when(clientServiceMock.findPublicationByPmid(pmid)).thenReturn(publication);
         when(clientServiceMock.findSubmissionsByPublicationAndUserId(publication.getId(), grant.getPi())).thenReturn(submissions);
         
         when(pmidLookupMock.retrievePubMedRecord(pmid)).thenReturn(pubMedRecordMock);
@@ -251,7 +253,9 @@ public class SubmissionTransformerTest {
         checkPmrValues(dto);
         
         assertEquals(false, dto.getSubmission().getSubmitted());
-        assertTrue(!dto.getSubmission().getRepositories().contains(ConfigUtil.getNihmsRepositoryUri()));
+        
+        assertTrue(dto.getSubmission().getRepositories().contains(ConfigUtil.getNihmsRepositoryUri()));
+        
         assertTrue(dto.getSubmission().getGrants().contains(grant.getId()));
         
         assertNull(dto.getSubmission().getSubmittedDate());

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-integration</artifactId>
   <name>NIHMS ELT Integration Tests</name>

--- a/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadITBase.java
+++ b/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadITBase.java
@@ -22,8 +22,12 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.After;
+import org.junit.Before;
+
 import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.client.PassClientFactory;
+import org.dataconservancy.pass.loader.nihms.util.FileUtil;
 import org.dataconservancy.pass.model.Grant;
 import org.dataconservancy.pass.model.Grant.AwardStatus;
 import org.joda.time.DateTime;
@@ -49,6 +53,22 @@ public abstract class TransformAndLoadITBase {
             System.setProperty("nihmsetl.data.dir", path);
         }
     }
+    
+    String cachepath = null;
+
+    @Before
+    public void startup() {
+        cachepath = FileUtil.getCurrentDirectory() +"/cache/compliant-cache.data";
+        System.setProperty("nihmsetl.loader.cachepath", cachepath);
+    }
+    
+    @After
+    public void cleanup() {
+        File cachefile = new File(cachepath);
+        if (cachefile.exists()) {
+            cachefile.delete();
+        }
+    }    
     
     protected final PassClient client = PassClientFactory.getPassClient();
     

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-etl-model</artifactId>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-util</artifactId>
   <name>NIHMS ETL Utilities</name>

--- a/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ConfigUtil.java
+++ b/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ConfigUtil.java
@@ -34,15 +34,29 @@ public class ConfigUtil {
     private static final String NIHMS_REPOSITORY_URI_KEY = "nihmsetl.repository.uri"; 
     private static final String NIHMS_REPOSITORY_URI_DEFAULT = "https://example.com/fedora/repositories/1";
                 
-    /** 
-     * Retrieve property from environment variable or set to default
-     * @param key
+    /**
+     * Retrieve property from a system property or renvironment variable or set to default
+     * <p>
+     * Given a string as a system property name (and a default) will:
+     * <ol>
+     * <li>Look up the system property with the matching name, and return it if defined</li>
+     * <li>Try to match an environment variable matching the key transformed TO_UPPER_CASE with periods substituted
+     * with underscores</li>
+     * <li>Use the default of none others match</li>
+     * </ol>
+     * </p>
+     *
+     * @param key - property/variable name in property-normal form (period separators, ideally all lowercas)
      * @param defaultValue
      * @return
      */
     public static String getSystemProperty(final String key, final String defaultValue) {
-        return System.getProperty(key, System.getenv().getOrDefault(key, defaultValue));
+        return System.getProperty(key, System.getenv().getOrDefault(toEnvName(key), defaultValue));
     }
+
+    static String toEnvName(String name) {
+        return name.toUpperCase().replace('.', '_');
+    }    
     
     
     /**

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-pass-client</artifactId>

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
@@ -139,8 +139,16 @@ public class NihmsPassClientService {
         Set<URI> grantIds = client.findAllByAttribute(Grant.class, AWARD_NUMBER_FLD, awardNumber);
         
         //try with no spaces
-        awardNumber = awardNumber.replaceAll("\\s+","");
-        grantIds.addAll(client.findAllByAttribute(Grant.class, AWARD_NUMBER_FLD, awardNumber));
+        String modAwardNum = awardNumber.replaceAll("\\s+","");
+        if (!awardNumber.equals(modAwardNum)) {
+            grantIds.addAll(client.findAllByAttribute(Grant.class, AWARD_NUMBER_FLD, modAwardNum));
+        }
+        
+        if (modAwardNum.length()>6 && modAwardNum.substring(5,6).equals("0")){
+            //try removing 0 on 6th character - COEUS data removes this
+            modAwardNum = modAwardNum.substring(0, 5) + modAwardNum.substring(6);
+            grantIds.addAll(client.findAllByAttribute(Grant.class, AWARD_NUMBER_FLD, modAwardNum));            
+        }
         
         List<Grant> grants = new ArrayList<Grant>();
         for (URI id : grantIds) {

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
@@ -171,9 +171,9 @@ public class NihmsPassClientService {
      * @param doi
      * @return
      */
-    public Publication findPublicationById(String pmid, String doi) {
+    public Publication findPublicationByPmid(String pmid) {
         if (pmid == null) {
-            throw new RuntimeException("PMID cannot be null when searching for existing Submission.");
+            throw new RuntimeException("PMID cannot be null when searching for existing Publication.");
         }
         
         //if the pmid/publicationId pair is in the cache, retrieve it.
@@ -183,7 +183,32 @@ public class NihmsPassClientService {
             publicationId = findPublicationByArticleId(pmid, "pmid");
         }
         
-        if (publicationId==null && doi!=null) {
+        if (publicationId!=null) {
+            Publication publication = readPublication(publicationId);
+            publicationCache.put(pmid, publicationId);
+            return publication;
+        }
+        
+        return null;
+    }
+    
+
+    /**
+     * Looks up publication using DOI, call should include pmid so that it can check publication
+     * cache first, then checks index for DOI
+     * @param pmid
+     * @param doi
+     * @return
+     */
+    public Publication findPublicationByDoi(String doi, String pmid) {
+        if (pmid == null) {
+            throw new RuntimeException("PMID cannot be null when searching for existing Publication.");
+        }
+
+        //if the pmid/publicationId pair is in the cache, retrieve it.
+        URI publicationId = publicationCache.get(pmid);
+        
+        if (doi!=null) {
             publicationId = findPublicationByArticleId(doi, "doi");
         }
         
@@ -195,6 +220,7 @@ public class NihmsPassClientService {
         
         return null;
     }
+    
 
     /**
      * Find NIHMS RepositoryCopy record for a publicationId

--- a/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
+++ b/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
@@ -131,7 +131,7 @@ public class NihmsPassClientServiceTest {
     
     
     /**
-     * Checks that it findGrantByAwardNumber returns URI when one found
+     * Checks that findGrantByAwardNumber returns URI when one found
      */
     @Test
     public void testFindGrantByAwardNumberHasMatch() throws Exception {
@@ -202,7 +202,7 @@ public class NihmsPassClientServiceTest {
         when(mockClient.findByAttribute(eq(Publication.class), eq("pmid"), eq(pmid))).thenReturn(publicationId);
         when(mockClient.readResource(eq(publicationId), eq(Publication.class))).thenReturn(publication);
         
-        Publication matchedPublication = clientService.findPublicationById(pmid, doi);
+        Publication matchedPublication = clientService.findPublicationByPmid(pmid);
         
         assertEquals(publication, matchedPublication);         
     }
@@ -223,9 +223,9 @@ public class NihmsPassClientServiceTest {
         when(mockClient.findByAttribute(Publication.class, "doi", doi)).thenReturn(publicationId);
         when(mockClient.readResource(publicationId, Publication.class)).thenReturn(publication);
         
-        Publication matchedPublication = clientService.findPublicationById(pmid, doi);
+        Publication matchedPublication = clientService.findPublicationByDoi(doi, pmid);
         
-        verify(mockClient, times(2)).findByAttribute(eq(Publication.class), any(), any());
+        verify(mockClient).findByAttribute(eq(Publication.class), any(), any());
         assertEquals(publication, matchedPublication);         
     }
 
@@ -239,9 +239,9 @@ public class NihmsPassClientServiceTest {
         when(mockClient.findByAttribute(Publication.class, "pmid", pmid)).thenReturn(null);
         when(mockClient.findByAttribute(Publication.class, "doi", doi)).thenReturn(null);
         
-        Publication matchedPublication = clientService.findPublicationById(pmid, doi);
+        Publication matchedPublication = clientService.findPublicationByPmid(pmid);
         
-        verify(mockClient, times(2)).findByAttribute(eq(Publication.class), Mockito.anyString(), any());
+        verify(mockClient).findByAttribute(eq(Publication.class), Mockito.anyString(), any());
         assertNull(matchedPublication);         
                 
     }  
@@ -283,8 +283,7 @@ public class NihmsPassClientServiceTest {
         
         assertNull(matchedRepoCopy);       
     }
-    
-    
+        
     
     /**
      * Tests the scenario where a match is found right away using publication+grant 

--- a/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
+++ b/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
@@ -161,7 +161,35 @@ public class NihmsPassClientServiceTest {
 
     
     /**
-     * Checks that it findPublicationById returns match based on PMID
+     * Checks that findGrantByAwardNumber will try awardNumber with the "0" removed at position 6
+     * if it fails to find one without the space.
+     */
+    @Test
+    public void testFindGrantByAwardNumberHasMatchWithRemoved0() throws Exception {
+        String awardNumWith0 = "R01AB01234";
+        String awardNumWithout0 = "R01AB1234";
+        Grant grant1 = new Grant();
+        grant1.setId(grantId);
+        grant1.setAwardNumber(awardNumWith0);
+        grant1.setStartDate(new DateTime().minusYears(1));
+
+        Set<URI> grantIds = new HashSet<URI>();
+        grantIds.add(grantId);
+        
+        when(mockClient.findAllByAttribute(eq(Grant.class), eq("awardNumber"), eq(awardNumWith0))).thenReturn(new HashSet<URI>());
+        when(mockClient.findAllByAttribute(eq(Grant.class), eq("awardNumber"), eq(awardNumWithout0))).thenReturn(grantIds);
+        when(mockClient.readResource(eq(grantId), eq(Grant.class))).thenReturn(grant1);
+
+        Grant matchedGrant = clientService.findMostRecentGrantByAwardNumber(awardNumWith0);
+        verify(mockClient).findAllByAttribute(eq(Grant.class), eq("awardNumber"), eq(awardNumWith0)); 
+        verify(mockClient).findAllByAttribute(eq(Grant.class), eq("awardNumber"), eq(awardNumWithout0)); 
+        
+        assertEquals(grant1, matchedGrant);        
+    }
+    
+    
+    /**
+     * Checks that findPublicationById returns match based on PMID
      */
     @Test
     public void testFindPublicationByIdPmidMatch() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>
@@ -48,20 +48,6 @@
     <module>nihms-etl-util</module>
   </modules>
 
-  <profiles>
-    <profile>
-      <id>external</id>
-      <activation>
-        <property>
-          <name>external</name>
-        </property>
-      </activation>
-      <properties>
-        <scp.port>122</scp.port>
-      </properties>
-    </profile>
-  </profiles>
-
   <build>    
     <pluginManagement>
       <plugins>
@@ -85,24 +71,6 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
-
-
-        <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
-           <artifactId>maven-deploy-plugin</artifactId>
-           <version>${maven.deploy.plugin.version}</version>
-           <configuration>
-             <retryFailedDeploymentCount>5</retryFailedDeploymentCount>
-           </configuration>
-           <!-- See https://jira.codehaus.org/browse/WAGON-393 -->
-           <dependencies>
-             <dependency>
-               <groupId>org.apache.maven.wagon</groupId>
-               <artifactId>wagon-ssh</artifactId>
-               <version>${maven.wagon.ssh.version}</version>
-             </dependency>
-           </dependencies>
         </plugin>
     
         <plugin>
@@ -288,21 +256,6 @@
       </snapshots>
     </repository>
   </repositories>
-
-  <distributionManagement>
-    <repository>
-      <id>dc.public.releases</id>
-      <name>Data Conservancy Release Maven Repository</name>
-      <url>scp://maven.dataconservancy.org:${scp.port}/data/maven-dc/public/releases/</url>
-    </repository>
-
-    <snapshotRepository>
-      <id>dc.public.snapshots</id>
-      <name>Data Conservancy Snapshot Maven Repository</name>
-      <url>scp://maven.dataconservancy.org:${scp.port}/data/maven-dc/public/snapshots/</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-
-  </distributionManagement>  
+  
   
 </project>


### PR DESCRIPTION
Several changes to improve performance:
* add cache of completed compliant records as local file. This saves compliant pmid and grant number combinations that are complete in that they are not going to require further changes in the database.
* added booleans to SubmissionDTO to indicate if anything changed to avoid unnecessary processing
Also:
* removed doi prefix to match ember
* grant lookup includes lookup with a "0" removed 
* changed handling of ConfigUtil.getSystemProperty to reformat environment variables to uppercase with underscores 
* increment version