### PR TITLE
Improve page wait for harvest util, increment version

### DIFF
--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   
   <artifactId>entrez-pmid-lookup</artifactId>

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   <artifactId>nihms-data-harvest-cli</artifactId>
   <packaging>jar</packaging>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
 
   <artifactId>nihms-data-harvest</artifactId>

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   <artifactId>nihms-data-transform-load-cli</artifactId>
   <name>NIHMS Data Transform/Load Command Line Interface</name>

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   <artifactId>nihms-data-transform-load</artifactId>
   <name>NIHMS Data Transform/Load</name>

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   <artifactId>nihms-etl-integration</artifactId>
   <name>NIHMS ELT Integration Tests</name>

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   
   <artifactId>nihms-etl-model</artifactId>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   <artifactId>nihms-etl-util</artifactId>
   <name>NIHMS ETL Utilities</name>

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   
   <artifactId>nihms-pass-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.2.2</version>
   <packaging>pom</packaging>
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>


### PR DESCRIPTION
Previously the page would time out without an error when large amounts of data were downloaded. This improves the wait.
Also increments version for release to be used in production.