### PR TITLE
Set DepositStatus to "accepted" if RepositoryCopy link added

### DIFF
--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   
   <artifactId>entrez-pmid-lookup</artifactId>

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   <artifactId>nihms-data-harvest-cli</artifactId>
   <packaging>jar</packaging>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
 
   <artifactId>nihms-data-harvest</artifactId>

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   <artifactId>nihms-data-transform-load-cli</artifactId>
   <name>NIHMS Data Transform/Load Command Line Interface</name>

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   <artifactId>nihms-data-transform-load</artifactId>
   <name>NIHMS Data Transform/Load</name>

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
@@ -19,6 +19,7 @@ import java.net.URI;
 
 import org.dataconservancy.pass.client.nihms.NihmsPassClientService;
 import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Deposit.DepositStatus;
 import org.dataconservancy.pass.model.Publication;
 import org.dataconservancy.pass.model.RepositoryCopy;
 import org.dataconservancy.pass.model.Submission;
@@ -26,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *
+ * Creates / updates the Submission, RepositoryCopy, Publication, and Deposit in the database as needed 
  * @author Karen Hanson
  */
 public class SubmissionLoader {
@@ -98,6 +99,7 @@ public class SubmissionLoader {
             Deposit deposit = clientService.findNihmsDepositForSubmission(submission.getId());
             if (deposit!=null && deposit.getRepositoryCopy()==null) {
                 deposit.setRepositoryCopy(repositoryCopyUri);
+                deposit.setDepositStatus(DepositStatus.ACCEPTED);
                 clientService.updateDeposit(deposit);
             } else if (deposit!=null && !deposit.getRepositoryCopy().equals(repositoryCopyUri)) {
                 //this shouldn't happen in principle, but if it does it should be checked.

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionLoaderTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionLoaderTest.java
@@ -267,7 +267,7 @@ public class SubmissionLoaderTest {
         
         Deposit deposit = new Deposit();
         deposit.setId(new URI(sDepositUri));
-        deposit.setDepositStatus(DepositStatus.ACCEPTED);
+        deposit.setDepositStatus(DepositStatus.SUBMITTED);
         deposit.setRepository(repositoryCopy.getRepository());
         
         SubmissionDTO dto = new SubmissionDTO();
@@ -295,6 +295,7 @@ public class SubmissionLoaderTest {
         ArgumentCaptor<Deposit> depositCaptor = ArgumentCaptor.forClass(Deposit.class);
         verify(clientServiceMock).updateDeposit(depositCaptor.capture()); 
         deposit.setRepositoryCopy(repositoryCopyUri);
+        deposit.setDepositStatus(DepositStatus.ACCEPTED);
         assertEquals(deposit, depositCaptor.getValue());
         
     }

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   <artifactId>nihms-etl-integration</artifactId>
   <name>NIHMS ELT Integration Tests</name>

--- a/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadCompliantIT.java
+++ b/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadCompliantIT.java
@@ -396,7 +396,7 @@ public class TransformAndLoadCompliantIT extends NihmsSubmissionEtlITBase {
         
         //check repository copy link added, but status did not change... status managed by deposit service
         Deposit deposit = client.readResource(preexistingDepositUri, Deposit.class);
-        assertEquals(preexistingDeposit.getDepositStatus(), deposit.getDepositStatus());
+        assertEquals(DepositStatus.ACCEPTED, deposit.getDepositStatus());
         assertEquals(repocopyUri, deposit.getRepositoryCopy());
                 
     }

--- a/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadInProcess.java
+++ b/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadInProcess.java
@@ -196,7 +196,7 @@ public class TransformAndLoadInProcess extends NihmsSubmissionEtlITBase {
         
         //check repository copy link added, but status did not change... status managed by deposit service
         Deposit deposit = client.readResource(preexistingDepositUri, Deposit.class);
-        assertEquals(preexistingDeposit.getDepositStatus(), deposit.getDepositStatus());
+        assertEquals(DepositStatus.ACCEPTED, deposit.getDepositStatus());
         assertEquals(repocopyUri, deposit.getRepositoryCopy());
         
     }

--- a/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadNonCompliant.java
+++ b/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadNonCompliant.java
@@ -196,7 +196,7 @@ public class TransformAndLoadNonCompliant extends NihmsSubmissionEtlITBase {
         
         //check repository copy link added, but status did not change... status managed by deposit service
         Deposit deposit = client.readResource(preexistingDepositUri, Deposit.class);
-        assertEquals(preexistingDeposit.getDepositStatus(), deposit.getDepositStatus());
+        assertEquals(DepositStatus.ACCEPTED, deposit.getDepositStatus());
         assertEquals(repocopyUri, deposit.getRepositoryCopy());
                 
     }

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   
   <artifactId>nihms-etl-model</artifactId>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   <artifactId>nihms-etl-util</artifactId>
   <name>NIHMS ETL Utilities</name>

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </parent>
   
   <artifactId>nihms-pass-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
-  <version>1.2.3</version>
+  <version>1.2.4</version>
   <packaging>pom</packaging>
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>


### PR DESCRIPTION
* If RepositoryCopy link is added to Deposit, NIHMS ETL now also updates DepositStatus to "accepted"
* Bump version to 1.2.4 for new release