### PR TITLE
Update to use model 3.1

### DIFF
--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   
   <artifactId>entrez-pmid-lookup</artifactId>

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   <artifactId>nihms-data-harvest-cli</artifactId>
   <packaging>jar</packaging>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>nihms-data-harvest</artifactId>

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   <artifactId>nihms-data-transform-load-cli</artifactId>
   <name>NIHMS Data Transform/Load Command Line Interface</name>

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   <artifactId>nihms-data-transform-load</artifactId>
   <name>NIHMS Data Transform/Load</name>

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -33,7 +33,12 @@
 	    <groupId>org.dataconservancy.pass</groupId>
 	    <artifactId>pass-model</artifactId>
 	</dependency>
-	
+		
+    <dependency>
+	    <groupId>org.dataconservancy.pass</groupId>
+	    <artifactId>pass-status-service</artifactId>
+	</dependency>
+		
     <dependency>
 	    <groupId>org.apache.commons</groupId>
 	    <artifactId>commons-csv</artifactId>

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.loader.nihms;
 
 import java.net.URI;
 
+import org.dataconservancy.pass.client.SubmissionStatusService;
 import org.dataconservancy.pass.client.nihms.NihmsPassClientService;
 import org.dataconservancy.pass.model.Deposit;
 import org.dataconservancy.pass.model.Deposit.DepositStatus;
@@ -109,6 +110,12 @@ public class SubmissionLoader {
             
         }
         
+        //before moving on do one last check to see if SubmissionStatus has been affected by the changes
+        //if so, update status.
+        if (dto.doUpdate()) {
+            SubmissionStatusService statusService = new SubmissionStatusService(submissionUri);
+            statusService.calculateAndUpdateSubmissionStatus();
+        }
     }    
     
 }

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionLoaderTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionLoaderTest.java
@@ -83,7 +83,7 @@ public class SubmissionLoaderTest {
         
         Submission submission = new Submission();
         submission.setPublication(new URI(sPublicationUri));
-        submission.setUser(new URI(sUserUri));
+        submission.setSubmitter(new URI(sUserUri));
 
         SubmissionDTO dto = new SubmissionDTO();
         dto.setPublication(publication);
@@ -128,7 +128,7 @@ public class SubmissionLoaderTest {
         publication.setPmid(pmid);
         
         Submission submission = new Submission();
-        submission.setUser(new URI(sUserUri));
+        submission.setSubmitter(new URI(sUserUri));
         submission.setPublication(publication.getId());
 
         SubmissionDTO dto = new SubmissionDTO();
@@ -170,7 +170,7 @@ public class SubmissionLoaderTest {
         Submission submission = new Submission();
         submission.setId(new URI(sSubmissionUri));
         submission.setPublication(new URI(sPublicationUri));
-        submission.setUser(new URI(sUserUri));
+        submission.setSubmitter(new URI(sUserUri));
 
         SubmissionDTO dto = new SubmissionDTO();
         dto.setPublication(publication);
@@ -204,7 +204,7 @@ public class SubmissionLoaderTest {
         
         Submission submission = new Submission();
         submission.setPublication(publication.getId());
-        submission.setUser(new URI(sUserUri));
+        submission.setSubmitter(new URI(sUserUri));
         
         RepositoryCopy repositoryCopy = new RepositoryCopy();
         repositoryCopy.setPublication(publication.getId());
@@ -258,7 +258,7 @@ public class SubmissionLoaderTest {
         Submission submission = new Submission();
         submission.setId(new URI(sSubmissionUri));
         submission.setPublication(publication.getId());
-        submission.setUser(new URI(sUserUri));
+        submission.setSubmitter(new URI(sUserUri));
         
         RepositoryCopy repositoryCopy = new RepositoryCopy();
         repositoryCopy.setPublication(publication.getId());

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
@@ -296,7 +296,7 @@ public class SubmissionTransformerTest {
         
         assertEquals(sGrantUri, dto.getSubmission().getGrants().get(0).toString());
         assertEquals(Source.OTHER, dto.getSubmission().getSource());  
-        assertEquals(sUserUri, dto.getSubmission().getUser().toString());
+        assertEquals(sUserUri, dto.getSubmission().getSubmitter().toString());
     }
 
         
@@ -350,7 +350,7 @@ public class SubmissionTransformerTest {
         
         submission.setRepositories(repositories);
         
-        submission.setUser(new URI(sUserUri));        
+        submission.setSubmitter(new URI(sUserUri));        
         
         return submission;
     }

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -65,7 +65,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.2-SNAPSHOT</name>
+              <name>oapass/fcrepo:4.7.5-3.1-SNAPSHOT</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
@@ -76,9 +76,9 @@
                   <FCREPO_STOMP_PORT>${FCREPO_STOMP_PORT}</FCREPO_STOMP_PORT>
                   <FCREPO_JMS_BASEURL>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</FCREPO_JMS_BASEURL>
                   <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
-                  <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld</COMPACTION_URI>
-                  <COMPACTION_PRELOAD_URI_PASS_STATIC>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld</COMPACTION_PRELOAD_URI_PASS_STATIC>
-                  <COMPACTION_PRELOAD_FILE_PASS_STATIC>/usr/local/tomcat/lib/context-2.2.jsonld</COMPACTION_PRELOAD_FILE_PASS_STATIC>
+                  <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld</COMPACTION_URI>
+                  <COMPACTION_PRELOAD_URI_PASS_STATIC>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.1.jsonld</COMPACTION_PRELOAD_URI_PASS_STATIC>
+                  <COMPACTION_PRELOAD_FILE_PASS_STATIC>/usr/local/tomcat/lib/context-3.1.jsonld</COMPACTION_PRELOAD_FILE_PASS_STATIC>
                 </env>
                 <ports>
                   <port>${FCREPO_PORT}:${FCREPO_PORT}</port>
@@ -94,7 +94,7 @@
                 </volumes>
                 <wait>
                   <http>
-                    <url>http://admin:moo@${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</url>
+                    <url>http://fedoraAdmin:moo@${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</url>
                   </http>
                   <time>120000</time>
                 </wait>
@@ -102,7 +102,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:0.0.10-2.2-SNAPSHOT</name>
+              <name>oapass/indexer:0.0.15-3.1-SNAPSHOT</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   <artifactId>nihms-etl-integration</artifactId>
   <name>NIHMS ELT Integration Tests</name>

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   
   <artifactId>nihms-etl-model</artifactId>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   <artifactId>nihms-etl-util</artifactId>
   <name>NIHMS ETL Utilities</name>

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.2.4</version>
+    <version>1.3.0</version>
   </parent>
   
   <artifactId>nihms-pass-client</artifactId>

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
@@ -265,9 +265,9 @@ public class NihmsPassClientService {
     
     
     /**
-     * Searches for Submissions matching a specific publication and User Id
+     * Searches for Submissions matching a specific publication and User Id (Submission.submitter)
      * @param pubId
-     * @param grantId
+     * @param userId
      * @return
      */
     public List<Submission> findSubmissionsByPublicationAndUserId(URI pubId, URI userId) {
@@ -284,7 +284,7 @@ public class NihmsPassClientService {
         
         Map<String,Object> attribs = new HashMap<String,Object>();
         attribs.put("publication", pubId);
-        attribs.put("user", userId);
+        attribs.put("submitter", userId);
         
         Set<URI> uris = client.findAllByAttributes(Submission.class, attribs);
         
@@ -451,7 +451,7 @@ public class NihmsPassClientService {
     public URI createSubmission(Submission submission) {
         URI submissionId = client.createResource(submission);
         LOG.info("New Submission created with URI {}", submissionId);          
-        String key = userIdPubIdKey(submission.getUser(), submission.getPublication());
+        String key = userIdPubIdKey(submission.getSubmitter(), submission.getPublication());
         userPubSubsCache.addToOrCreateEntry(key,submissionId);        
         return submissionId;
     }
@@ -494,7 +494,7 @@ public class NihmsPassClientService {
             client.updateResource(submission);
             
             //shouldnt be necessary, but just to be sure... make sure this is in cache:
-            String key = userIdPubIdKey(submission.getUser(), submission.getPublication());
+            String key = userIdPubIdKey(submission.getSubmitter(), submission.getPublication());
             userPubSubsCache.addToOrCreateEntry(key,submission.getId());
             
             LOG.info("Submission with URI {} was updated ", submission.getId());

--- a/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
+++ b/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
@@ -290,7 +290,7 @@ public class NihmsPassClientServiceTest {
         verify(mockClient).findAllByAttributes(eq(Submission.class), argumentCaptor.capture());
         
         assertEquals(2, argumentCaptor.getValue().size());
-        assertEquals(userId, argumentCaptor.getValue().get("user"));
+        assertEquals(userId, argumentCaptor.getValue().get("submitter"));
         assertEquals(publicationId, argumentCaptor.getValue().get("publication"));
         
         assertEquals(submission, matchedSubmissions.get(0));
@@ -316,7 +316,7 @@ public class NihmsPassClientServiceTest {
         verify(mockClient).findAllByAttributes(eq(Submission.class), argumentCaptor.capture());
         
         assertEquals(2, argumentCaptor.getValue().size());
-        assertEquals(userId, argumentCaptor.getValue().get("user"));
+        assertEquals(userId, argumentCaptor.getValue().get("submitter"));
         assertEquals(publicationId, argumentCaptor.getValue().get("publication"));
         
         assertTrue(matchedSubmissions.size()==0);
@@ -374,7 +374,7 @@ public class NihmsPassClientServiceTest {
     @Test
     public void testCreateSubmission() {
         Submission submission = new Submission();
-        submission.setUser(userId);
+        submission.setSubmitter(userId);
         submission.setPublication(publicationId);
         
         when(mockClient.createResource(eq(submission))).thenReturn(submissionId);
@@ -394,14 +394,14 @@ public class NihmsPassClientServiceTest {
     public void testUpdateSubmissionHasChanges() {
         Submission submission = new Submission();
         submission.setId(submissionId);
-        submission.setUser(userId);
+        submission.setSubmitter(userId);
         submission.setPublication(publicationId);
         submission.setSubmitted(false);
 
         //make a submission that is different
         Submission submissionEdited = new Submission();
         submissionEdited.setId(submissionId);
-        submissionEdited.setUser(userId);
+        submissionEdited.setSubmitter(userId);
         submissionEdited.setPublication(publicationId);
         submissionEdited.setSubmitted(true);
         

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
-  <version>1.2.4</version>
+  <version>1.3.0</version>
   <packaging>pom</packaging>
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <org-json.version>20180130</org-json.version>
     <commons-csv.version>1.5</commons-csv.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <pass-client.version>0.3.3-SNAPSHOT</pass-client.version>
+    <pass-client.version>0.4.1-SNAPSHOT</pass-client.version>
     <logback.version>1.2.3</logback.version>
     <selenium.version>3.11.0</selenium.version>
     <args4j.version>2.33</args4j.version>
@@ -156,6 +156,12 @@
       <dependency>
         <groupId>org.dataconservancy.pass</groupId>
         <artifactId>pass-model-nihms</artifactId>
+        <version>${pass-client.version}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.dataconservancy.pass</groupId>
+        <artifactId>pass-status-service</artifactId>
         <version>${pass-client.version}</version>
       </dependency>
       


### PR DESCRIPTION
This includes:
* Using `Submission.submitter` in place of `Submission.user` 
* Incorporating the `Submission.submissionStatus` calculation
* Pointing to latest `java-fedora-client`
* Incrementing version number to `1.3.0`

Closes #21 
Requires https://github.com/OA-PASS/java-fedora-client/pull/64