### PR TITLE
Add printout of variables on app run

### DIFF
--- a/nihms-data-harvest-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsHarvesterApp.java
+++ b/nihms-data-harvest-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsHarvesterApp.java
@@ -85,6 +85,21 @@ public class NihmsHarvesterApp {
                     + "To use a config file, create a file named \"{}\" in the app's folder or provide a valid path "
                     + "using the \"{}\" environment variable.", configFile.getAbsolutePath(), DEFAULT_CONFIG_FILENAME, NIHMS_CONFIG_FILEPATH_PROPKEY);
         }
+
+        if (LOG.isDebugEnabled()) {
+            StringBuilder props = new StringBuilder("\n"
+                        + "--------------------------------------------------------------\n"
+                        + "*                         PROPERTIES                         *\n"
+                        + "--------------------------------------------------------------\n");
+            
+            props.append(NIHMS_CONFIG_FILEPATH_PROPKEY + ": " + configFile.toString());
+            
+            for (String key : SYSTEM_PROPERTIES) {
+                props.append(key + ": " + ConfigUtil.getSystemProperty(key, "{uses_default}"));
+            }
+            props.append("--------------------------------------------------------------\n");
+            LOG.debug(props.toString());
+        }
         
         NihmsHarvester harvester = new NihmsHarvester();
         harvester.harvest(statusesToProcess, startDate);        

--- a/nihms-data-transform-load-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsTransformLoadApp.java
+++ b/nihms-data-transform-load-cli/src/main/java/org/dataconservancy/pass/loader/nihms/cli/NihmsTransformLoadApp.java
@@ -46,8 +46,9 @@ public class NihmsTransformLoadApp {
      */
     private static final String[] SYSTEM_PROPERTIES = {"pass.fedora.user", "pass.fedora.password", 
                                                        "pass.fedora.baseurl", "pass.elasticsearch.url",
-                                                       "pass.elasticsearch.limit","nihmsetl.repository.uri",
-                                                       "nihmsetl.pmcurl.template", "nihmsetl.loader.cachepath"};
+                                                       "pass.elasticsearch.limit", "nihmsetl.data.dir",
+                                                       "nihmsetl.repository.uri", "nihmsetl.pmcurl.template", 
+                                                       "nihmsetl.loader.cachepath"};
         
     private Set<NihmsStatus> statusesToProcess;
 
@@ -80,6 +81,21 @@ public class NihmsTransformLoadApp {
                     + "using the \"nihms.config.filepath\" environment variable.", configFile.getAbsolutePath(), DEFAULT_CONFIG_FILENAME);
         }
 
+        if (LOG.isDebugEnabled()) {
+            StringBuilder props = new StringBuilder("\n"
+                        + "--------------------------------------------------------------\n"
+                        + "*                         PROPERTIES                         *\n"
+                        + "--------------------------------------------------------------\n");
+            
+            props.append(NIHMS_CONFIG_FILEPATH_PROPKEY + ": " + configFile.toString());
+            
+            for (String key : SYSTEM_PROPERTIES) {
+                props.append(key + ": " + ConfigUtil.getSystemProperty(key, "{uses_default}"));
+            }
+            props.append("--------------------------------------------------------------\n");
+            LOG.debug(props.toString());
+        }
+        
         NihmsTransformLoadService service = new NihmsTransformLoadService();
         service.transformAndLoadFiles(statusesToProcess);
         


### PR DESCRIPTION
Some background: all vars used in NIHMS ETL can come from one of 4 places, and this is ordered in the following priority: (1) the properties passed in through the properties file (2) system properties (3) environment variables (4) default value. This is dealt with when calling ConfigUtils.getSystemProperty()

close #25 