### PR TITLE
Upgrade PASS Java client to version 0.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <org-json.version>20180130</org-json.version>
     <commons-csv.version>1.5</commons-csv.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <pass-client.version>0.5.2</pass-client.version>
+    <pass-client.version>0.5.3</pass-client.version>
     <logback.version>1.2.3</logback.version>
     <selenium.version>3.11.0</selenium.version>
     <args4j.version>2.33</args4j.version>


### PR DESCRIPTION
The client upgrade includes support for `DRAFT` submission status, and updates the submission status calculation to account for the DRAFT status.

Supports resolution of #29 