### PR TITLE
Support the maven-release-plugin for performing releases

### DIFF
--- a/entrez-pmid-lookup/pom.xml
+++ b/entrez-pmid-lookup/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>entrez-pmid-lookup</artifactId>

--- a/entrez-pmid-lookup/src/main/java/org/dataconservancy/pass/entrez/PmidLookup.java
+++ b/entrez-pmid-lookup/src/main/java/org/dataconservancy/pass/entrez/PmidLookup.java
@@ -70,8 +70,8 @@ public class PmidLookup {
 
     /**
      * Retrieve PubMedRecord object for PMID record from NIH's Entrez API service. 
-     * @param pmid
-     * @return
+     * @param pmid pub med id
+     * @return the record
      */
     public PubMedEntrezRecord retrievePubMedRecord(String pmid) {
         JSONObject jsonObj = retrievePubMedRecordAsJson(pmid);
@@ -85,8 +85,8 @@ public class PmidLookup {
      * or null if no match found. Note that "no match found" means there is no record for that pmid, whereas
      * a RuntimeException means communication with the service failed, and the client app can decide what 
      * to do about those.
-     * @param pmid
-     * @return
+     * @param pmid pub med id
+     * @return the record as a JSON object
      */
     public JSONObject retrievePubMedRecordAsJson(String pmid) {
         if (pmid == null) {
@@ -111,8 +111,8 @@ public class PmidLookup {
     
     /**
      * Calls the Entrez API and finds the root of the JSON record
-     * @param pmid
-     * @return
+     * @param pmid pub med id
+     * @return the root JSON record
      */
     private JSONObject retrieveJsonFromApi(String pmid) {
         JSONObject root = null;
@@ -156,9 +156,9 @@ public class PmidLookup {
      * Converts to JSONObject then walks to the root of the JSON content. This could be a PMID record
      * or an error message
      * @param jsonEntrezRecord as string
-     * @param pmid
-     * @return
-     * @throws IOException
+     * @param pmid pub med id
+     * @return the root JSON object
+     * @throws IOException if there's an error reading the record
      */
     private JSONObject walkToJsonRoot(String jsonEntrezRecord, String pmid) throws IOException {
         JSONObject root = new JSONObject(jsonEntrezRecord);

--- a/entrez-pmid-lookup/src/main/java/org/dataconservancy/pass/entrez/PubMedEntrezRecord.java
+++ b/entrez-pmid-lookup/src/main/java/org/dataconservancy/pass/entrez/PubMedEntrezRecord.java
@@ -46,7 +46,7 @@ public class PubMedEntrezRecord {
     /**
      * Instantiate a PubMedRecord by passing in a JSONObject representing a single result from the 
      * PubMed database of the Entrez API. The root of this record starts at the PMID if the results JSON. Here is a sample record:
-     * https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json&rettype=full&id=27771272
+     * <a href="https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&amp;retmode=json&amp;rettype=full&amp;id=27771272">https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&amp;retmode=json&amp;rettype=full&amp;id=27771272</a>
      * @param entrezJson JSONObject for single PubMed record from Entrez API.
      */
     public PubMedEntrezRecord(JSONObject entrezJson) {

--- a/nihms-data-harvest-cli/pom.xml
+++ b/nihms-data-harvest-cli/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-harvest-cli</artifactId>
   <packaging>jar</packaging>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>nihms-data-harvest</artifactId>

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/FileWatcher.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/FileWatcher.java
@@ -37,10 +37,10 @@ public class FileWatcher {
     
     /**
      * Polls a directory until it finds a file matching the criteria, passes back the file name.
-     * @param directoryPath
-     * @param matchPrefix
-     * @param matchFileExtension
-     * @return
+     * @param directory directory to poll
+     * @param matchPrefix the filename prefix
+     * @param matchFileExtension the filename extension
+     * @return the matching file
      */
     public static File getNewFile(Path directory, String matchPrefix, String matchFileExtension) {  
 

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
@@ -101,10 +101,6 @@ public class NihmsHarvester {
     
     /**
      * Initiate harvester with required properties
-     * 
-     * @param downloadDirectoryPath
-     * @param nihmsUser
-     * @param nihmsPasswrd
      */
     public NihmsHarvester() {
         this.downloadDirectoryPath = FileUtil.getDataDirectory().toPath();
@@ -257,9 +253,9 @@ public class NihmsHarvester {
     
     /**
      * Waits for page to load, checks URL matches expected URL. Throws error if times out
-     * @param loadingUrl
-     * @param driver
-     * @throws InterruptedException
+     * @param loadingUrl the url
+     * @param driver the driver
+     * @throws InterruptedException if the current thread is interrupted
      */
     private void waitForPageToLoad(String loadingUrl, WebDriver driver) throws InterruptedException {
         long start_time = System.currentTimeMillis();

--- a/nihms-data-transform-load-cli/pom.xml
+++ b/nihms-data-transform-load-cli/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load-cli</artifactId>
   <name>NIHMS Data Transform/Load Command Line Interface</name>

--- a/nihms-data-transform-load/pom.xml
+++ b/nihms-data-transform-load/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-data-transform-load</artifactId>
   <name>NIHMS Data Transform/Load</name>

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/CompletedPublicationsCache.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/CompletedPublicationsCache.java
@@ -65,8 +65,8 @@ public class CompletedPublicationsCache {
     
     /**
      * Add pmid/awardNumber combination to set
-     * @param pmid
-     * @param awardNumber
+     * @param pmid pub med id
+     * @param awardNumber award number
      */
     public synchronized void add(String pmid, String awardNumber) {
         if (!nullOrEmpty(pmid) && !nullOrEmpty(awardNumber) 
@@ -83,8 +83,9 @@ public class CompletedPublicationsCache {
     
     /**
      * Check if it contains pmid/award number combination
-     * @param key
-     * @return
+     * @param pmid pub med id
+     * @param awardNumber award number
+     * @return true if the id/award number combo is cached
      */
     public synchronized boolean contains(String pmid, String awardNumber) {
         if (!nullOrEmpty(pmid) && !nullOrEmpty(awardNumber)) {
@@ -96,7 +97,7 @@ public class CompletedPublicationsCache {
 
     /**
      * Get number of items in cache
-     * @return
+     * @return the size of the cache
      */
     public synchronized int size() {
         return completedPubsCache.size();

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsCsvProcessor.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsCsvProcessor.java
@@ -112,7 +112,7 @@ public class NihmsCsvProcessor {
     /**
      * Cycles through the CSV that is loaded, converting to a NihmsPublication, and then
      * using the consumer provided to process the record
-     * @param pubConsumer
+     * @param pubConsumer the consumer
      */
     public void processCsv(Consumer<NihmsPublication> pubConsumer) {
         
@@ -141,8 +141,8 @@ public class NihmsCsvProcessor {
 
     /**
      * Converts Row to a NihmsPublication object and passes it the consumer provided
-     * @param row
-     * @param rowConsumer
+     * @param row the row
+     * @param pubConsumer the row consumer
      */
     private void consumeRow(CSVRecord row, Consumer<NihmsPublication> pubConsumer) {
         if (row==null) {return;}
@@ -168,8 +168,8 @@ public class NihmsCsvProcessor {
      * Validates that the headers in the spreadsheet match what is expected before retrieving data from them
      * This will go through all headers even if the first one is not valid so that all issues with headers are
      * logged as errors before exiting
-     * @param headers
-     * @return
+     * @param headers CSVRrecord headers
+     * @return true if the headers match the {@link #EXPECTED_HEADERS}
      */
     private boolean hasValidHeaders(CSVRecord headers) {
         boolean valid = true;
@@ -189,8 +189,9 @@ public class NihmsCsvProcessor {
     /**
      * Cycles through Submission status types, and matches it to the filepath to determine
      * the status of the rows in the CSV file. If no match is found, an exception is thrown.
-     * @param path
-     * @return
+     * @param path the file path
+     * @return the status
+     * @throws RuntimeException if the status could not be determined
      */
     public static NihmsStatus nihmsStatus(Path path) {
         String filename = path.getFileName().toString();

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -87,7 +87,6 @@ public class NihmsPublicationToSubmission {
     
     /**
      * Constructor uses defaults for client service and pmid lookup
-     * @param clientService
      */
     public NihmsPublicationToSubmission() {
         this.pmidLookup = new PmidLookup();
@@ -98,7 +97,8 @@ public class NihmsPublicationToSubmission {
     /**
      * Constructor initiates with the required NIHMS Client Service and PMID lookup
      * Useful to pass in an existing clientService to reuse cache 
-     * @param clientService
+     * @param clientService PASS client
+     * @param pmidLookup Entrez client
      */
     public NihmsPublicationToSubmission(NihmsPassClientService clientService, PmidLookup pmidLookup) {
         if (clientService==null) {
@@ -122,8 +122,8 @@ public class NihmsPublicationToSubmission {
     /**
      * Does the heavy lifting of converting a NihmsPublication record into the NihmsSubmissionDTO 
      * that is needed for the NihmsLoader to write it to Fedora
-     * @param pub
-     * @return
+     * @param pub the publication
+     * @return the DTO, never {@code null}
      */
     public SubmissionDTO transform(NihmsPublication pub) {
                 
@@ -200,9 +200,9 @@ public class NihmsPublicationToSubmission {
     /**
      * Ideally, uses the record from Entrez to populate publication details, but in the absence of that
      * this will create a publication with what we have in the NihmsPublication
-     * @param nihmsPub
-     * @param pmr
-     * @return
+     * @param nihmsPub the publication
+     * @param pmr the pubmed record
+     * @return the Publication, never {@code null}
      */
     private Publication initiateNewPublication(NihmsPublication nihmsPub, PubMedEntrezRecord pmr) {
         LOG.info("No existing publication found for PMID \"{}\", initiating new Publication record", nihmsPub.getPmid());
@@ -425,9 +425,9 @@ public class NihmsPublicationToSubmission {
      * what NIHMS says and log the fact as a warning. If this calc returns NULL, a repository copy should
      * not have been created 
      * 
-     * @param pub
-     * @param currDepositStatus
-     * @return
+     * @param pub the publication
+     * @param currCopyStatus current RepositoryCopy CopyStatus
+     * @return the new copy status, may be {@code null}
      */
     public static CopyStatus calcRepoCopyStatus(NihmsPublication pub, CopyStatus currCopyStatus) {
         if (pub.getNihmsStatus().equals(NihmsStatus.COMPLIANT)) {

--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/SubmissionLoader.java
@@ -50,8 +50,8 @@ public class SubmissionLoader {
     
     /**
      * Supports initiation with specific client service
-     * @param clientService
-     * @param statusService
+     * @param clientService PASS client service
+     * @param statusService Submission status service
      */
     public SubmissionLoader(NihmsPassClientService clientService, SubmissionStatusService statusService) {
         this.clientService = clientService;
@@ -62,7 +62,7 @@ public class SubmissionLoader {
     /**
      * Load the data in the NihmsSubmissionDTO to the database. Deal with any conflicts that occur during the updates
      * by implementing retries, failing gracefully etc.
-     * @param dto
+     * @param dto the DTO
      */
     public void load(SubmissionDTO dto) {
         if (dto==null || dto.getSubmission()==null) {

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -102,7 +102,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:0.0.17-3.2-SNAPSHOT</name>
+              <name>oapass/indexer@sha256:e51092a9d433219d52207f1ec3f5ea7c652d51f516bcbe9434dae556b921546d</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>
@@ -115,6 +115,7 @@
                   <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
                   <PI_TYPE_PREFIX>http://oapass.org/ns/pass#</PI_TYPE_PREFIX>
                   <PI_LOG_LEVEL>debug</PI_LOG_LEVEL>
+                  <PI_ES_CONFIG>/app/esconfig-3.4.json</PI_ES_CONFIG>
                 </env>
                 <links>
                   <link>fcrepo:localhost</link>

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-integration</artifactId>
+  <version>1.3.1-SNAPSHOT</version>
   <name>NIHMS ELT Integration Tests</name>
 
   <profiles>

--- a/nihms-etl-integration/pom.xml
+++ b/nihms-etl-integration/pom.xml
@@ -29,8 +29,8 @@
     </profile>
   </profiles>
   <properties>
-    <FCREPO_HOST>localhost</FCREPO_HOST>
-    <ES_HOST>localhost</ES_HOST>
+    <FCREPO_HOST>${docker.host.address}</FCREPO_HOST>
+    <ES_HOST>${docker.host.address}</ES_HOST>
   </properties>
 
   <build>
@@ -70,7 +70,7 @@
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
                 <env>
-                  <FCREPO_HOST>${FCREPO_HOST}</FCREPO_HOST>
+                  <FCREPO_HOST>fcrepo</FCREPO_HOST>
                   <FCREPO_PORT>${FCREPO_PORT}</FCREPO_PORT>
                   <FCREPO_JMS_PORT>${FCREPO_JMS_PORT}</FCREPO_JMS_PORT>
                   <FCREPO_STOMP_PORT>${FCREPO_STOMP_PORT}</FCREPO_STOMP_PORT>
@@ -108,10 +108,10 @@
                 <env>
                   <PI_FEDORA_USER>fedoraAdmin</PI_FEDORA_USER>
                   <PI_FEDORA_PASS>moo</PI_FEDORA_PASS>
-                  <PI_FEDORA_INTERNAL_BASE>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest/</PI_FEDORA_INTERNAL_BASE>
+                  <PI_FEDORA_INTERNAL_BASE>http://fcrepo:${FCREPO_PORT}/fcrepo/rest/</PI_FEDORA_INTERNAL_BASE>
                   <PI_ES_BASE>http://elasticsearch:9200/</PI_ES_BASE>
                   <PI_ES_INDEX>http://elasticsearch:9200/pass/</PI_ES_INDEX>
-                  <PI_FEDORA_JMS_BROKER>tcp://${FCREPO_HOST}:${FCREPO_JMS_PORT}</PI_FEDORA_JMS_BROKER>
+                  <PI_FEDORA_JMS_BROKER>tcp://fcrepo:${FCREPO_JMS_PORT}</PI_FEDORA_JMS_BROKER>
                   <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
                   <PI_TYPE_PREFIX>http://oapass.org/ns/pass#</PI_TYPE_PREFIX>
                   <PI_LOG_LEVEL>debug</PI_LOG_LEVEL>

--- a/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadSmokeIT.java
+++ b/nihms-etl-integration/src/test/java/org/dataconservancy/pass/loader/nihms/integration/TransformAndLoadSmokeIT.java
@@ -62,12 +62,16 @@ public class TransformAndLoadSmokeIT extends NihmsSubmissionEtlITBase {
             final Set<URI> repoCopies = client.findAllByAttribute(RepositoryCopy.class, "@type", "RepositoryCopy");
             assertEquals(26, repoCopies.size());
         });
-        
-        Set<URI> publications = client.findAllByAttribute(Publication.class, "@type", "Publication");
-        assertEquals(37, publications.size());
-        
-        Set<URI> submissions = client.findAllByAttribute(Submission.class, "@type", "Submission");
-        assertEquals(45, submissions.size());
+
+        attempt(RETRIES, () -> {
+            Set<URI> publications = client.findAllByAttribute(Publication.class, "@type", "Publication");
+            assertEquals(37, publications.size());
+        });
+
+        attempt(RETRIES, () -> {
+            Set<URI> submissions = client.findAllByAttribute(Submission.class, "@type", "Submission");
+            assertEquals(45, submissions.size());
+        });
         
         //reset file names:
         File downloadDir = new File(path);

--- a/nihms-etl-model/pom.xml
+++ b/nihms-etl-model/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-etl-model</artifactId>

--- a/nihms-etl-util/pom.xml
+++ b/nihms-etl-util/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>nihms-etl-util</artifactId>
   <name>NIHMS ETL Utilities</name>

--- a/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ConfigUtil.java
+++ b/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ConfigUtil.java
@@ -38,17 +38,17 @@ public class ConfigUtil {
      * Retrieve property from a system property or renvironment variable or set to default
      * <p>
      * Given a string as a system property name (and a default) will:
+     * </p>
      * <ol>
      * <li>Look up the system property with the matching name, and return it if defined</li>
      * <li>Try to match an environment variable matching the key transformed TO_UPPER_CASE with periods substituted
      * with underscores</li>
      * <li>Use the default of none others match</li>
      * </ol>
-     * </p>
      *
      * @param key - property/variable name in property-normal form (period separators, ideally all lowercas)
-     * @param defaultValue
-     * @return
+     * @param defaultValue default value for the key if it does not exist as a system property or environment variable
+     * @return the property value
      */
     public static String getSystemProperty(final String key, final String defaultValue) {
         return System.getProperty(key, System.getenv().getOrDefault(toEnvName(key), defaultValue));
@@ -61,7 +61,7 @@ public class ConfigUtil {
     
     /**
      * Retrieves the NIHMS Repository URI based on property key
-     * @return
+     * @return the NIHMS repository URI
      */
     public static URI getNihmsRepositoryUri() {
         try {
@@ -77,7 +77,6 @@ public class ConfigUtil {
      * 
      * @param propertiesFile - the properties {@code File} to be read
      * @return the Properties object derived from the supplied {@code File}
-     * @throws NihmsHarvesterException if the properties file could not be accessed.
      */
     public static Properties loadProperties(File propertiesFile)  {
         Properties properties = new Properties();

--- a/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/FileUtil.java
+++ b/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/FileUtil.java
@@ -39,7 +39,7 @@ public class FileUtil {
     
     /**
      * Gets directory that the app was run from
-     * @return
+     * @return the current directory
      */
     public static String getCurrentDirectory() {
         try {
@@ -78,8 +78,8 @@ public class FileUtil {
     
     /**
      * Retrieve a list of files in a directory, filter by directory
-     * @param directory
-     * @return
+     * @param directory the directory
+     * @return the file listing
      */
     public static List<Path> getCsvFilePaths(Path directory) {
         List<Path> filepaths = null;
@@ -120,7 +120,7 @@ public class FileUtil {
 
     /**
      * Rename file to append ".done" once it has been processed
-     * @param path
+     * @param path the path to rename
      */
     public static void renameToDone(Path path) {
         final File file = path.toFile();

--- a/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ProcessingUtil.java
+++ b/nihms-etl-util/src/main/java/org/dataconservancy/pass/loader/nihms/util/ProcessingUtil.java
@@ -32,8 +32,8 @@ public class ProcessingUtil {
     
     /**
      * Returns true if a string is empty or null
-     * @param str
-     * @return
+     * @param str the string, may be {@code null}
+     * @return true if a string is empty or null
      */
     public static boolean nullOrEmpty(String str) {
         return (str==null || str.isEmpty());
@@ -41,8 +41,8 @@ public class ProcessingUtil {
 
     /** 
      * Returns true if a collection has 0 rows or is null
-     * @param collection
-     * @return
+     * @param collection the collection, may be {@code null}
+     * @return true if a collection has 0 rows or is null
      */
     public static boolean nullOrEmpty(Collection<?> collection) {
         return (collection==null || collection.isEmpty());
@@ -52,9 +52,9 @@ public class ProcessingUtil {
     /**
      * Formats a dateto a joda datetime according to pattern provided. If pattern is null, defaults to yyyy-MM-dd. 
      * Returns null if no date passed in
-     * @param date
+     * @param date a date
      * @param pattern e.g. MM/dd/yyyy
-     * @return
+     * @return the DateTime for the supplied {@code date}
      */
     public static DateTime formatDate(String date, String pattern) {
         if (nullOrEmpty(date)) {

--- a/nihms-pass-client/pom.xml
+++ b/nihms-pass-client/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-nihms-submission-etl</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>nihms-pass-client</artifactId>

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
@@ -121,8 +121,8 @@ public class NihmsPassClientService {
     /**
      * Searches for Grant record using awardNumber. Tries this first using the awardNumber as passed in,
      * then again without spaces.
-     * @param awardNumber
-     * @return
+     * @param awardNumber the award number
+     * @return the grant, or {@code null} if not found
      */
     public Grant findMostRecentGrantByAwardNumber(String awardNumber) {
         if (nullOrEmpty(awardNumber)) {
@@ -169,9 +169,8 @@ public class NihmsPassClientService {
     /**
      * Looks up publication using PMID, since this is the most reliable field to match. Checks publication
      * cache first, then checks index
-     * @param pmid
-     * @param doi
-     * @return
+     * @param pmid the pub med id
+     * @return the publication, or {@code null} if it can't be found
      */
     public Publication findPublicationByPmid(String pmid) {
         if (pmid == null) {
@@ -198,9 +197,9 @@ public class NihmsPassClientService {
     /**
      * Looks up publication using DOI, call should include pmid so that it can check publication
      * cache first, then checks index for DOI
-     * @param pmid
-     * @param doi
-     * @return
+     * @param doi the digital object identifier
+     * @param pmid the pub med id
+     * @return the publication, or {@code null} if it can't be found
      */
     public Publication findPublicationByDoi(String doi, String pmid) {
         if (pmid == null) {
@@ -226,8 +225,8 @@ public class NihmsPassClientService {
 
     /**
      * Find NIHMS RepositoryCopy record for a publicationId
-     * @param pubId
-     * @return
+     * @param pubId the publication id
+     * @return the repository copy, or {@code null} if it can't be found
      */
     public RepositoryCopy findNihmsRepositoryCopyForPubId(URI pubId) {
         if (pubId == null) {
@@ -266,9 +265,9 @@ public class NihmsPassClientService {
     
     /**
      * Searches for Submissions matching a specific publication and User Id (Submission.submitter)
-     * @param pubId
-     * @param userId
-     * @return
+     * @param pubId the publication id
+     * @param userId the user id
+     * @return the submissions, may be empty but never {@code null}
      */
     public List<Submission> findSubmissionsByPublicationAndUserId(URI pubId, URI userId) {
         if (pubId == null) {
@@ -309,9 +308,9 @@ public class NihmsPassClientService {
     /**      
      * Searches for Publication record using articleIds. This detects whether we are dealing
      * with a record that was already looked at previously. 
-     * @param articleId
+     * @param articleId the artical id
      * @param idFieldName the name of the field on the Submission model that will be matched e.g. "pmid" or "doi"
-     * @return
+     * @return the publication, or {@code null} if it can't be found
      */
     private URI findPublicationByArticleId(String articleId, String idFieldName) {
         if (nullOrEmpty(articleId)) {
@@ -327,8 +326,8 @@ public class NihmsPassClientService {
     
     /**
      * Look up Journal URI using ISSN
-     * @param issn
-     * @return
+     * @param issn the issn
+     * @return the journal for the ISSN, may be {@code null} if not found
      */
     public URI findJournalByIssn(String issn) {
         if (nullOrEmpty(issn)) {
@@ -340,8 +339,8 @@ public class NihmsPassClientService {
     
     /**
      * Searches for a NIHMS Deposit that matches a SubmissionID
-     * @param submissionId
-     * @return
+     * @param submissionId the submission id
+     * @return the deposit associated with the submission, may be {@code null} if not found
      */
     public Deposit findNihmsDepositForSubmission(URI submissionId) {
         if (submissionId == null) {
@@ -377,7 +376,7 @@ public class NihmsPassClientService {
     
      /**
      * Retrieve full grant record from database
-     * @param grantId
+     * @param grantId the grant id
      * @return Grant if found, or null if not found
      */
     private Grant readGrant(URI grantId){
@@ -391,7 +390,7 @@ public class NihmsPassClientService {
     
     /**
      * Retrieve full publication record from database
-     * @param publicationId
+     * @param publicationId the publication id
      * @return Publication if found, or null if not found
      */
     public Publication readPublication(URI publicationId){
@@ -405,7 +404,7 @@ public class NihmsPassClientService {
     
     /**
      * Retrieve full Submission record
-     * @param submissionId
+     * @param submissionId the submission id
      * @return matching submission or null if none found
      */
     public Submission readSubmission(URI submissionId) {
@@ -419,8 +418,8 @@ public class NihmsPassClientService {
 
     /**
      * Retrieve full deposit record from database
-     * @param depositId
-     * @return
+     * @param depositId the deposit id
+     * @return the deposit, or null if not found
      */
     public Deposit readDeposit(URI depositId){
         if (depositId == null) {
@@ -432,8 +431,8 @@ public class NihmsPassClientService {
 
     
     /**
-     * @param publication
-     * @return
+     * @param publication the publication
+     * @return the uri of the created publication
      */
     public URI createPublication(Publication publication) {
         URI publicationId = client.createResource(publication);
@@ -445,8 +444,8 @@ public class NihmsPassClientService {
     
     
     /**
-     * @param submission
-     * @return
+     * @param submission the submission
+     * @return the uri of the created submission
      */
     public URI createSubmission(Submission submission) {
         URI submissionId = client.createResource(submission);
@@ -458,8 +457,8 @@ public class NihmsPassClientService {
     
 
     /**
-     * @param respositoryCopy
-     * @return
+     * @param repositoryCopy the repository copy
+     * @return the uri of the created repository copy
      */
     public URI createRepositoryCopy(RepositoryCopy repositoryCopy) {
         URI repositoryCopyId = client.createResource(repositoryCopy);
@@ -470,7 +469,7 @@ public class NihmsPassClientService {
 
     /**
      * 
-     * @param publication
+     * @param publication the publication
      * @return true if record needed to be updated, false if no update
      */
     public boolean updatePublication(Publication publication) {
@@ -485,7 +484,7 @@ public class NihmsPassClientService {
     
     
     /**
-     * @param submission
+     * @param submission the submission
      * @return true if record needed to be updated, false if no update
      */
     public boolean updateSubmission(Submission submission) {
@@ -505,7 +504,7 @@ public class NihmsPassClientService {
     
 
     /**
-     * @param repositoryCopy
+     * @param repositoryCopy the repository copy
      * @return true if record needed to be updated, false if no update
      */
     public boolean updateRepositoryCopy(RepositoryCopy repositoryCopy) {
@@ -519,7 +518,7 @@ public class NihmsPassClientService {
     }
     
     /**
-     * @param deposit
+     * @param deposit the deposit
      * @return true if record needed to be updated, false if no update
      */
     public boolean updateDeposit(Deposit deposit) {

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/GrantIdCache.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/GrantIdCache.java
@@ -41,8 +41,8 @@ public class GrantIdCache {
     
     /**
      * Add awardNumber/grantId combination to map
-     * @param awardNumber
-     * @param grantId
+     * @param awardNumber the award number
+     * @param grantId the grant id
      */
     public synchronized void put(String awardNumber, URI grantId) {
         awardNumber = awardNumber.toLowerCase();
@@ -51,8 +51,8 @@ public class GrantIdCache {
     
     /**
      * Retrieve grantId by awardNumber
-     * @param key
-     * @return
+     * @param awardNumber the award number
+     * @return the grant id
      */
     public synchronized URI get(String awardNumber) {
         awardNumber = awardNumber.toLowerCase();
@@ -61,7 +61,7 @@ public class GrantIdCache {
 
     /**
      * Remove a Grant from cache
-     * @param awardNumber
+     * @param awardNumber the award number
      */
     public synchronized void remove(String awardNumber) {
         awardNumber = awardNumber.toLowerCase();
@@ -70,7 +70,7 @@ public class GrantIdCache {
 
     /**
      * Get number of cached grants
-     * @return
+     * @return number of cached grants
      */
     public synchronized int size() {
         return grantCache.size();

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/NihmsDepositIdCache.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/NihmsDepositIdCache.java
@@ -42,8 +42,8 @@ public class NihmsDepositIdCache {
     
     /**
      * Add deposit to map
-     * @param submission
-     * @param depositId
+     * @param submissionId the submission id
+     * @param depositId the deposit id
      */
     public synchronized void put(URI submissionId, URI depositId) {
         depositCache.put(submissionId, depositId);
@@ -51,8 +51,8 @@ public class NihmsDepositIdCache {
     
     /**
      * Retrieve depositId by submissionId
-     * @param key
-     * @return
+     * @param submissionId the submission id
+     * @return the URI from the deposit cache
      */
     public synchronized URI get(URI submissionId) {
         return depositCache.get(submissionId);
@@ -60,7 +60,7 @@ public class NihmsDepositIdCache {
 
     /**
      * Remove a Deposit from cache
-     * @param submission
+     * @param submissionId the submission id
      */
     public synchronized void remove(URI submissionId) {
         depositCache.remove(submissionId);
@@ -68,7 +68,7 @@ public class NihmsDepositIdCache {
 
     /**
      * Get number of cached deposits
-     * @return
+     * @return the number of cached deposits
      */
     public synchronized int size() {
         return depositCache.size();

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/NihmsRepositoryCopyIdCache.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/NihmsRepositoryCopyIdCache.java
@@ -42,8 +42,8 @@ public class NihmsRepositoryCopyIdCache {
     
     /**
      * Add publicationId to repositoryCopyId mapping 
-     * @param publicationId
-     * @param repositoryCopyId
+     * @param publicationId the publication id
+     * @param repositoryCopyId the repository copy it
      */
     public synchronized void put(URI publicationId, URI repositoryCopyId) {
         nihmsRepoCopyCache.put(publicationId, repositoryCopyId);
@@ -51,8 +51,8 @@ public class NihmsRepositoryCopyIdCache {
     
     /**
      * Retrieve RepositoryCopyId by publicationId
-     * @param publicationId
-     * @return
+     * @param publicationId the publication id
+     * @return the repository copy id
      */
     public synchronized URI get(URI publicationId) {
         return nihmsRepoCopyCache.get(publicationId);
@@ -60,7 +60,7 @@ public class NihmsRepositoryCopyIdCache {
 
     /**
      * Remove a publicationId to repositoryCopyId mapping from cache
-     * @param pmid
+     * @param publicationId the publication id
      */
     public synchronized void remove(URI publicationId) {
         nihmsRepoCopyCache.remove(publicationId);
@@ -68,7 +68,7 @@ public class NihmsRepositoryCopyIdCache {
 
     /**
      * Get number of cached mappings
-     * @return
+     * @return the cache size
      */
     public synchronized int size() {
         return nihmsRepoCopyCache.size();

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/PublicationIdCache.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/PublicationIdCache.java
@@ -41,8 +41,8 @@ public class PublicationIdCache {
     
     /**
      * Add publication to map
-     * @param key
-     * @param value
+     * @param pmid the pmid
+     * @param publicationId the publication id
      */
     public synchronized void put(String pmid, URI publicationId) {
         publicationCache.put(pmid, publicationId);
@@ -50,8 +50,8 @@ public class PublicationIdCache {
     
     /**
      * Retrieve publicationId by pmid
-     * @param key
-     * @return
+     * @param pmid the pmid
+     * @return the publication uri
      */
     public synchronized URI get(String pmid) {
         return publicationCache.get(pmid);
@@ -59,7 +59,7 @@ public class PublicationIdCache {
 
     /**
      * Remove a Publication from cache
-     * @param pmid
+     * @param pmid the pmid
      */
     public synchronized void remove(String pmid) {
         publicationCache.remove(pmid);
@@ -67,7 +67,7 @@ public class PublicationIdCache {
 
     /**
      * Get number of cached publications
-     * @return
+     * @return the size of the cache
      */
     public synchronized int size() {
         return publicationCache.size();

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/UserPubSubmissionsCache.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/cache/UserPubSubmissionsCache.java
@@ -44,8 +44,8 @@ public class UserPubSubmissionsCache {
     
     /**
      * Add an item to an existing Map Entry or create a new one if one does not already exist
-     * @param userIdPubId
-     * @param submissionId
+     * @param userIdPubId the concatenated user id and publication id
+     * @param submissionId the submission id
      */
     public synchronized void addToOrCreateEntry(String userIdPubId, URI submissionId) {
         Set<URI> submissionIds = userPubSubmissionsCache.get(userIdPubId);
@@ -59,8 +59,8 @@ public class UserPubSubmissionsCache {
     
     /**
      * Add userIdPubId/submissionIds combination to map
-     * @param userIdPubId
-     * @param submissionIds
+     * @param userIdPubId the concatenated user id and publication id
+     * @param submissionIds the submission ids
      */
     public synchronized void put(String userIdPubId, Set<URI> submissionIds) {
         userPubSubmissionsCache.put(userIdPubId, submissionIds);
@@ -68,8 +68,8 @@ public class UserPubSubmissionsCache {
     
     /**
      * Retrieve submissionIds by userIdPubId
-     * @param key
-     * @return
+     * @param userIdPubId the concatenated user id and publication id
+     * @return submission ids
      */
     public synchronized Set<URI> get(String userIdPubId) {
         return userPubSubmissionsCache.get(userIdPubId);
@@ -77,7 +77,7 @@ public class UserPubSubmissionsCache {
 
     /**
      * Remove a Submission from cache
-     * @param userIdPubId
+     * @param userIdPubId the concatenated user id and publication id
      */
     public synchronized void remove(String userIdPubId) {
         userPubSubmissionsCache.remove(userIdPubId);
@@ -85,7 +85,7 @@ public class UserPubSubmissionsCache {
 
     /**
      * Get number of cached submissions
-     * @return
+     * @return the size of the cache
      */
     public synchronized int size() {
         return userPubSubmissionsCache.size();

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
   
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.12</junit.version>
@@ -221,6 +222,19 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>${maven-release-plugin.version}</version>
+          <configuration>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+            <pushChanges>false</pushChanges>
+            <localCheckout>true</localCheckout>
+            <preparationGoals>clean install</preparationGoals>
+            <releaseProfiles>release</releaseProfiles>
+          </configuration>
         </plugin>
         
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-nihms-submission-etl</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,12 @@
       </releases>
     </repository>
   </repositories>
-  
-  
+
+  <scm>
+    <connection>scm:git:https://github.com/OA-PASS/nihms-submission-etl.git</connection>
+    <developerConnection>scm:git:https://github.com/OA-PASS/nihms-submission-etl.git</developerConnection>
+    <url>https://github.com/OA-PASS/nihms-submission-etl</url>
+    <tag>HEAD</tag>
+  </scm>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,20 +48,6 @@
     <module>nihms-etl-util</module>
   </modules>
 
-  <profiles>
-    <profile>
-      <id>external</id>
-      <activation>
-        <property>
-          <name>external</name>
-        </property>
-      </activation>
-      <properties>
-        <scp.port>122</scp.port>
-      </properties>
-    </profile>
-  </profiles>
-
   <build>    
     <pluginManagement>
       <plugins>
@@ -242,74 +228,34 @@
       
     </dependencies>
   </dependencyManagement>
-  
-  <repositories>
-  
-    <repository>
-      <id>dc.public.releases</id>
-      <name>Data Conservancy Public Maven Repository (releases)</name>
-      <layout>default</layout>
-      <url>http://maven.dataconservancy.org/public/releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    
-    <repository>
-      <id>dc.public.snapshots</id>
-      <name>Data Conservancy Public Maven Repository (snapshots)</name>
-      <layout>default</layout>
-      <url>http://maven.dataconservancy.org/public/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    
-    <repository>
-      <id>dc.private.releases</id>
-      <name>Data Conservancy Private Maven Repository (releases)</name>
-      <url>scp://maven.dataconservancy.org:${scp.port}/data/maven-dc/private/releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>dc.private.snapshots</id>
-      <name>Data Conservancy Private Maven Repository (snapshots)</name>
-      <url>scp://maven.dataconservancy.org:${scp.port}/data/maven-dc/private/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 
   <distributionManagement>
+
     <repository>
-      <id>dc.public.releases</id>
-      <name>Data Conservancy Release Maven Repository</name>
-      <url>scp://maven.dataconservancy.org:${scp.port}/data/maven-dc/public/releases/</url>
+      <id>maven-central-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
 
     <snapshotRepository>
-      <id>dc.public.snapshots</id>
-      <name>Data Conservancy Snapshot Maven Repository</name>
-      <url>scp://maven.dataconservancy.org:${scp.port}/data/maven-dc/public/snapshots/</url>
+      <id>maven-central-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <uniqueVersion>false</uniqueVersion>
     </snapshotRepository>
 
-  </distributionManagement>  
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>oss</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
   
   
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
   <properties>
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
-    <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>
+    <docker-maven-plugin.version>0.28.0</docker-maven-plugin.version>
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
     <maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,77 @@
 
   <name>PASS NIHMS Submission Extract-Transform-Load</name>
 
-  <properties>
-    <scp.port>22</scp.port>
+  <url>https://github.com/OA-PASS/nihms-submission-etl</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Aaron Birkland</name>
+      <email>apb@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins Univeristy</organization>
+      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Karen Hanson</name>
+      <email>karen.hanson@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins Univeristy</organization>
+      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins Univeristy</organization>
+      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Elliot Metsger</name>
+      <email>emetsger@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins Univeristy</organization>
+      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>${maven-gpg-plugin.version}</version>
+              <executions>
+                <execution>
+                  <id>sign-artifacts</id>
+                  <phase>verify</phase>
+                  <goals>
+                    <goal>sign</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <useAgent>true</useAgent>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <properties>
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
@@ -21,6 +89,8 @@
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
     <maven.wagon.ssh.version>2.10</maven.wagon.ssh.version>
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
+    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
   
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.12</junit.version>
@@ -120,9 +190,58 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${maven-gpg-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <useAgent>true</useAgent>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencyManagement>


### PR DESCRIPTION
- Adds Maven boilerplate supporting the `maven-release-plugin`, `maven-gpg-plugin`, `maven-javadoc-plugin`, and `maven-source-plugin`
- Support releasing to Maven Central
- Addresses Javadoc issues that would otherwise fail the build
- Upgrades to `1.3.1-SNAPSHOT` from `1.3.0` in anticipation of using `maven-release-plugin` for releases
- Upgrades to the latest `oapass/indexer` image: `oapass/indexer:0.0.18-3.4`
- Upgrades the `docker-maven-plugin`
- Fixes a timing issue with `TransformAndLoadSmokeIT`


Supports resolution of #29 