### PR TITLE
Do not attempt to link Publication to Journal

### DIFF
--- a/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/nihms-data-transform-load/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -215,13 +215,6 @@ public class NihmsPublicationToSubmission {
             publication.setDoi(pmr.getDoi());
             publication.setVolume(pmr.getVolume());
             publication.setIssue(pmr.getIssue());
-            
-            URI journalUri = clientService.findJournalByIssn(pmr.getIssn());
-            if (journalUri == null) {
-                //try ESSN
-                journalUri = clientService.findJournalByIssn(pmr.getEssn());
-            }
-            publication.setJournal(journalUri);
         } else {
             publication.setTitle(nihmsPub.getArticleTitle());
         }

--- a/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
+++ b/nihms-data-transform-load/src/test/java/org/dataconservancy/pass/loader/nihms/SubmissionTransformerTest.java
@@ -292,7 +292,6 @@ public class SubmissionTransformerTest {
         assertEquals(issue, dto.getPublication().getIssue());
         assertEquals(pmid, dto.getPublication().getPmid());
         assertEquals(doi, dto.getPublication().getDoi());
-        assertEquals(sJournalUri, dto.getPublication().getJournal().toString());   
         
         assertEquals(sGrantUri, dto.getSubmission().getGrants().get(0).toString());
         assertEquals(Source.OTHER, dto.getSubmission().getSource());  

--- a/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
+++ b/nihms-pass-client/src/main/java/org/dataconservancy/pass/client/nihms/NihmsPassClientService.java
@@ -66,6 +66,9 @@ public class NihmsPassClientService {
 
     public static final String SUBMITTER_FLD = "submitter";
 
+    static final String ERR_CREATE_PUBLICATION =
+            "Refusing to create a Publication: it must have either a DOI or a PMID.";
+
     private PassClient client;
 
     /**
@@ -445,6 +448,12 @@ public class NihmsPassClientService {
      * @return the uri of the created publication
      */
     public URI createPublication(Publication publication) {
+
+        // Publication resource must have either a PMID or a DOI
+        if (publication.getPmid() == null && publication.getDoi() == null) {
+                throw new RuntimeException(ERR_CREATE_PUBLICATION);
+        }
+
         URI publicationId = client.createResource(publication);
         LOG.info("New Publication created with URI {}", publicationId);   
         //add to local cache for faster lookup

--- a/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
+++ b/nihms-pass-client/src/test/java/org/dataconservancy/pass/client/nihms/NihmsPassClientServiceTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import static org.dataconservancy.pass.client.nihms.NihmsPassClientService.ERR_CREATE_PUBLICATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -48,6 +49,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -425,6 +427,47 @@ public class NihmsPassClientServiceTest {
         clientService.updateSubmission(submission);
         verify(mockClient, never()).updateResource(any());
     }
-    
-    
+
+    /**
+     * Creating a Publication with null DOI and a non-null PMID should succeed
+     */
+    @Test
+    public void createPublicationWithNullDoi() {
+        Publication p = new Publication();
+        p.setDoi(null);
+        p.setPmid("pmid");
+        clientService.createPublication(p);
+
+        verify(mockClient).createResource(p);
+    }
+
+    /**
+     * Creating a Publication with non-null DOI and a null PMID should succeed
+     */
+    @Test
+    public void createPublicationWithNullPmid() {
+        Publication p = new Publication();
+        p.setDoi("doi");
+        p.setPmid(null);
+        clientService.createPublication(p);
+
+        verify(mockClient).createResource(p);
+    }
+
+    /**
+     * Creating a Publication with null DOI and a null PMID should fail
+     */
+    @Test
+    public void createPublicationWithNullPmidAndNullDoi() {
+        expectedEx.expect(RuntimeException.class);
+        expectedEx.expectMessage(ERR_CREATE_PUBLICATION);
+
+        Publication p = new Publication();
+        p.setDoi(null);
+        p.setPmid(null);
+        clientService.createPublication(p);
+
+        verifyZeroInteractions(mockClient);
+
+    }
 }


### PR DESCRIPTION
Eliminates the search for Journal by I- or E-SSN.
Insures every Publication created by NIHMS ETL has a PMID or DOI that can be later used to resolve a journal.

Commits 14bbf5d..6bb74e9.

Closes #34.