### PR TITLE
Upgrade to version 0.6.0 of the PASS client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <org-json.version>20180130</org-json.version>
     <commons-csv.version>1.5</commons-csv.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <pass-client.version>0.5.3</pass-client.version>
+    <pass-client.version>0.6.0</pass-client.version>
     <logback.version>1.2.3</logback.version>
     <selenium.version>3.11.0</selenium.version>
     <args4j.version>2.33</args4j.version>


### PR DESCRIPTION
Identical to 0.5.3, but the version number is congruent with a binary incompatibility introduced in 0.5.3.