### PR TITLE
Harvest using NIHMS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # PASS NIHMS Submission ETL
-The NIHMS Submission ETL contains the components required to download, transform and load Submission information from NIHMS to PASS. The project includes two command line tools. The first uses Selenium to log into the NIHMS website and download the CSV(s) containing compliant, non-compliant, and in-process publication information. The second tool reads those files, transforms the data to the PASS data model and then loads them to PASS.
+The NIHMS Submission ETL contains the components required to download, transform and load Submission information from NIHMS to PASS. The project includes two command line tools. The first uses the NIH API to download the CSV(s) containing compliant, non-compliant, and in-process publication information. The second tool reads those files, transforms the data to the PASS data model and then loads them to PASS.
+
+For background information on PACM, see the [user guide](https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/static/pacm-user-guide.pdf).  Limited information on using the PACM API can be found [here](https://www.nlm.nih.gov/pubs/techbull/mj19/brief/mj19_api_public_access_compliance.html).
 
 ## NIHMS Data Harvest CLI
-The NIHMS Data Harvest CLI uses Selenium with the FireFox drivers to log in and navigate the NIH PACM website. 
+The NIHMS Data Harvest CLI uses the NIH API to download the PACM data. 
 
 ### Pre-requisites
 The following are required to run this tool:
 * Java 8 or later
 * Download the latest nihms-data-harvest-cli-{version}-shaded.jar from the [releases page](https://github.com/OA-PASS/nihms-submission-etl/releases) and place in a folder on the machine where the application will run.
-* Install FireFox (version 55 or later) on the machine that will run the harvester. You do not need to be able to open the browser, the application will run in "headless" mode.
-* Download the [geckodriver](https://github.com/mozilla/geckodriver/releases/tag/v0.20.1) (v0.20.1 has been tested) unzip the folder, locate the geckodriver executable and move it to a convenient location.
-* Get an account for the NIH PACM website
+* Get an account for the NIH PACM website, and obtain an API key.
 * Create a data folder that files will be downloaded to.
 
 ### Data Harvest Configuration
 There are several ways to configure the Data Harvest CLI. You can use a configuration file, environment variables, system variables, or a combination of these. The configuration file will set system properties. In the absence of a config file, system properties will be used, and in the absence of those, environment variables will be used. Note that to use environment variables, the system property name must be converted to upper case, and the periods replaced with underscores. For example, to define `nihmsetl.data.dir` as an environment variable, use `NIHMSETL_DATA_DIR` instead.
+
+> **Note**: URL parameters specified using system properties named `nihmsetl.api.url.param.<param name>` cannot be specified as _environment variables_.  They may only be specified as system properties or in the `nihms-harvest.properties` file.
 
 By default, the application will look for a configuration file named `nihms-harvest.properties` in the folder containing the java application. You can override the location of the properties file by defining an environment variable for `nihmsetl.harvester.configfile` e.g. 
 ```
@@ -22,16 +24,62 @@ By default, the application will look for a configuration file named `nihms-harv
 ```
 
 The configuration file should look like this: 
-```
-nihmsetl.data.dir=/path/to/pass/loaders/data
-webdriver.gecko.driver=/path/to/geckodriver.exe
-nihmsetl.harvester.username=username
-nihmsetl.harvester.password=password
-```
+```properties
+# Example properties file for nihms-data-harvest-cli
+#
+# Defines a folder to download CSV files to. If it doesn’t exist, it will create it for you.
+# Will default to ./data in the folder the Java app runs in
+# nihmsetl.data.dir=data
+#
 
-* `nihmsetl.data.dir` is the path where downloaded files will be saved to. If a path is not defined, a `/data` folder will be created in the folder containing the Java application. 
-* `webdriver.gecko.driver` is the location of the geckodriver executable. It defaults to the folder containing the Java application 
-* `nihmsetl.harvester.username` and `nihmsetl.harvester.password` are the credentials for the NIH PACM site.
+# NIH API hostname
+nihmsetl.api.host = www.ncbi.nlm.nih.gov
+
+# HTTP scheme
+nihmsetl.api.scheme = https
+
+# Currently the port is not used
+# nihmsetl.api.port = 
+
+# NIH API URL path
+nihmsetl.api.path = /pmc/utils/pacm/
+
+# Allow 30 seconds for a request to be read before timing out
+nihmsetl.http.read-timeout-ms = 30000
+
+# Allow 30 seconds for establishing connections before timing out
+nihmsetl.http.connect-timeout-ms = 30000
+
+
+# URL Parameters
+#   Additional parameters may be added, and they will be included in the API URL as request parameters
+#   Parameters may be added as 'nihmsetl.api.url.param.<parameter name>' where '<parameter name>' is the
+#   URL request parameter
+
+# Format ought to be CSV, otherwise the loader won't be able to process the saved files
+nihmsetl.api.url.param.format = csv
+
+# Institution name, unclear as to how it is used
+nihmsetl.api.url.param.inst = JOHNS HOPKINS UNIVERSITY
+
+#  IPF (Institutional Profile File) number, the unique ID assigned to a grantee organization in the eRA system. 
+nihmsetl.api.url.param.ipf = 4134401
+
+# The API token retrieved from the PACM website.  These expire every three months.
+nihmsetl.api.url.param.api-token = XXXXXXX-XXXX-XXXX-XXXXXX
+
+# Date in MM/YYYY format that the PACM data should start from (may be set using the `-s` harvester command line option).  By default this date will be set to the current month, one year ago 
+# nihmsetl.api.url.param.pdf = 07/2018
+
+# Date in MM/YYYY format that the PACM data should end at (leave commented to default to the current month)
+# nihmsetl.api.url.param.pdt = 07/2019
+
+# Undocumented, not used
+# nihmsetl.api.url.param.rd =
+
+# Undocumented, not used
+# nihmsetl.api.url.param.filter =
+```
 
 ### Running the Data Harvester
 Once the Data Harvest CLI has been configured, there are a few additional options you can add when running from the command line.

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -13,16 +13,6 @@
   <dependencies>
   
     <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-firefox-driver</artifactId>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-java</artifactId>
-    </dependency>
-  
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -47,6 +37,11 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
     </dependency>
 
     <dependency>

--- a/nihms-data-harvest/pom.xml
+++ b/nihms-data-harvest/pom.xml
@@ -38,7 +38,17 @@
       <artifactId>nihms-etl-model</artifactId>
 	  <version>${project.parent.version}</version>
     </dependency>
-        
+
+    <dependency>
+      <groupId>com.damnhandy</groupId>
+      <artifactId>handy-uri-templates</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
@@ -17,25 +17,26 @@ package org.dataconservancy.pass.loader.nihms;
 
 import java.io.File;
 
-import java.net.URLEncoder;
-
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.commons.io.IOUtils;
 import org.dataconservancy.pass.loader.nihms.model.NihmsStatus;
 import org.dataconservancy.pass.loader.nihms.util.FileUtil;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxBinary;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.firefox.FirefoxProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,69 +49,25 @@ import static org.dataconservancy.pass.loader.nihms.util.ProcessingUtil.nullOrEm
 public class NihmsHarvester {
 
     private static final Logger LOG = LoggerFactory.getLogger(NihmsHarvester.class);
-    
-    //properties needed to setup FireFox driver
-    private static final String DOWNLOAD_DIRECTORY_PROPNAME = "browser.download.dir";
-    private static final String DOWNLOAD_FOLDERLIST_PROPNAME = "browser.download.folderList";
-    private static final String NEVERASK_SAVETODISK_PROPNAME = "browser.helperApps.neverAsk.saveToDisk";
-    private static final String DOWNLOAD_SHOWWHENSTART_PROPNAME = "browser.download.manager.showWhenStarting";
-    private static final String DOWNLOAD_ALLOWEDAUTO_MIMETYPE = "text/csv";
-    private static final String GECKODRIVER_PATH_PROPNAME = "webdriver.gecko.driver";
-    private static final String HEADLESS_MODE = "--headless";
-    
-    private static final Integer PAGELOAD_WAIT_TIMEOUT = 20;
-    
-    private static final String COMPLIANT_FILE_PREFIX = "Compliant ";
-    private static final String NONCOMPLIANT_FILE_PREFIX = "Noncompliant ";
-    private static final String INPROCESS_FILE_PREFIX = "In process";
-    
-    
-    //page elements
-    private static final String START_URL = "https://www.ncbi.nlm.nih.gov/account/pacm/?back_url=https%3A%2F%2Fwww%2Encbi%2Enlm%2Enih%2Egov%2Fpmc%2Futils%2Fpacm%2Flogin";
-    private static final String GUI_LOGIN_FRAME = "loginframe";    
-    private static final String GUI_ERA_SIGNIN_BUTTON_XPATH = "//img[@alt='Sign in with eRA Commons']";
-    private static final String GUI_USER_FIELD_NAME = "USER";
-    private static final String GUI_PASSWORD_FIELD_NAME = "PASSWORD";
-    private static final String GUI_LOGIN_BUTTON_ID = "Image2";
-    private static final String GUI_DOWNLOAD_LINKTEXT = "Download as CSV file";
-    private static final String GUI_NONCOMPLIANT_URL = "https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/n?";
-    private static final String GUI_COMPLIANT_URL = "https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/c?";
-    private static final String GUI_INPROGRESS_URL = "https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/p?";
-    
-    private static final String GUI_NONCOMPLIANT_LINK_XPATH = "//a[starts-with(@href, 'https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/n?')]";
-    private static final String GUI_COMPLIANT_LINK_XPATH = "//a[starts-with(@href, 'https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/c?')]";
-    private static final String GUI_INPROCESS_LINK_XPATH = "//a[starts-with(@href, 'https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/p?')]";
-    private static final String STARTDATE_FILTER_URL_TEMPLATE = "https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/s?pdf=%s";
-    private static final String GUI_SIGNOUT_LINK = "https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/logout";
-    
-    /**
-     * Login username for NIHMS website
-     */
-    private String nihmsUser;
-    
-    /**
-     * Login password for NIHMS website
-     */
-    private String nihmsPasswrd;
-    
+
     /**
      * Directory to download files to
      */
     private Path downloadDirectoryPath;
-    
-    
+
+    private UrlBuilder urlBuilder;
+
+    private OkHttpClient okHttp;
+
     /**
      * Initiate harvester with required properties
      */
     public NihmsHarvester() {
         this.downloadDirectoryPath = FileUtil.getDataDirectory().toPath();
-        this.nihmsUser = NihmsHarvesterConfig.getUserName();
-        this.nihmsPasswrd = NihmsHarvesterConfig.getPassword();
-                
+        this.urlBuilder = new UrlBuilder();
+
         if (downloadDirectoryPath==null) {throw new RuntimeException("The harvester's downloadDirectory cannot be empty");}
-        if (nullOrEmpty(nihmsUser)) {throw new RuntimeException("The harvester's nihmsUser cannot be empty");}
-        if (nullOrEmpty(nihmsPasswrd)) {throw new RuntimeException("The harvester's nihmsPasswrd cannot be empty");}
-                
+
         //if download directory doesn't already exist attempt to make it
         if (!Files.isDirectory(downloadDirectoryPath)) {
             LOG.warn("Download directory does not exist at path provided. A new directory will be created at path: {}", downloadDirectoryPath);
@@ -119,11 +76,16 @@ public class NihmsHarvester {
                 throw new RuntimeException("A new download directory could not be created at path: {}. Please provide a valid path for the downloads");
             }
         }
+
+        okHttp = new OkHttpClient.Builder()
+                .connectTimeout(NihmsHarvesterConfig.getHttpConnectTimeoutMs(), TimeUnit.MILLISECONDS)
+                .readTimeout(NihmsHarvesterConfig.getHttpReadTimeoutMs(), TimeUnit.MILLISECONDS)
+                .build();
     }
-    
+
     /**
      * Retrieve files from NIHMS based on status list and startDate provided
-     * 
+     *
      * @param statusesToDownload list of {@code NihmsStatus} types to download from the NIHMS website
      * @param startDate formatted as {@code yyyy-mm}, can be null to default to 1 year prior to harvest date
      */
@@ -133,116 +95,67 @@ public class NihmsHarvester {
         }
         if (!validStartDate(startDate)) {
             throw new RuntimeException(String.format("The startDate %s is not valid. The date must be formatted as yyyy-mm", startDate));
-        }   
-        
-        WebDriver driver = null;
-        
+        }
+
         try {
-            //make sure the property is set as expected
-            System.setProperty(GECKODRIVER_PATH_PROPNAME, NihmsHarvesterConfig.getGeckoDriverPath());
-    
-            FirefoxBinary firefoxBinary = new FirefoxBinary();
-            firefoxBinary.addCommandLineOptions(HEADLESS_MODE);
-            
-            FirefoxProfile profile = new FirefoxProfile();
-            //Set Location to store files after downloading. 
-            profile.setPreference(DOWNLOAD_DIRECTORY_PROPNAME, downloadDirectoryPath.toString());
             LOG.info("Writing files to: {}", downloadDirectoryPath.toString());
-            profile.setPreference(DOWNLOAD_FOLDERLIST_PROPNAME, 2);
-     
-            //Set Preference to not show file download confirmation dialogue using MIME types Of different file extension types.
-            profile.setPreference(NEVERASK_SAVETODISK_PROPNAME, DOWNLOAD_ALLOWEDAUTO_MIMETYPE); 
-            profile.setPreference(DOWNLOAD_SHOWWHENSTART_PROPNAME, false );
-    
-            FirefoxOptions options = new FirefoxOptions();        
-            options.setProfile(profile);
-            options.setBinary(firefoxBinary);
-            
-            driver = new FirefoxDriver(options);
-    
-            driver.manage().timeouts().implicitlyWait(PAGELOAD_WAIT_TIMEOUT, TimeUnit.SECONDS);
-            
-            LOG.debug("Opening Selenium driver");
-            //get to era login
-            driver.get(START_URL);
-    
-            LOG.debug("First login options page loaded");
-            
-            driver.switchTo().frame(GUI_LOGIN_FRAME);
-            driver.findElement(By.xpath(GUI_ERA_SIGNIN_BUTTON_XPATH)).click();
-            
-            driver.switchTo().defaultContent();
-            
-            LOG.debug("selecting era commons option");
-            //enter login info
-            driver.findElement(By.id(GUI_USER_FIELD_NAME)).click();
-            driver.findElement(By.id(GUI_USER_FIELD_NAME)).sendKeys(nihmsUser);
-            driver.findElement(By.id(GUI_PASSWORD_FIELD_NAME)).click();
-            driver.findElement(By.id(GUI_PASSWORD_FIELD_NAME)).sendKeys(nihmsPasswrd);
-    
-            LOG.debug("Entered username/pass into form");
-            driver.findElement(By.id(GUI_LOGIN_BUTTON_ID)).click();
-            LOG.info("Logged into NIHMS download page");
-            
+
+            Map<String, String> params = new HashMap<>();
+
             if (!nullOrEmpty(startDate)) {
                 startDate = startDate.replace("-", "/");
                 LOG.info("Filtering with Start Date " + startDate);
-                String filteredUrl = String.format(STARTDATE_FILTER_URL_TEMPLATE, URLEncoder.encode(startDate, "UTF-8"));
-                driver.get(filteredUrl);
-            }
-            
-            if (statusesToDownload.contains(NihmsStatus.COMPLIANT)) {
-                driver.findElement(By.xpath(GUI_COMPLIANT_LINK_XPATH)).click();     
-                LOG.info("Goto compliant list");             
-                waitForPageToLoad(GUI_COMPLIANT_URL, driver);  
-                driver.findElement(By.linkText(GUI_DOWNLOAD_LINKTEXT)).click(); 
-                String newfile = pollAndRename(COMPLIANT_FILE_PREFIX, NihmsStatus.COMPLIANT);    
-                LOG.info("Downloaded and saved compliant publications as file " + newfile);     
-                Thread.sleep(2000);     
-            }        
-            
-            if (statusesToDownload.contains(NihmsStatus.NON_COMPLIANT)) {
-                driver.findElement(By.xpath(GUI_NONCOMPLIANT_LINK_XPATH)).click();     
-                LOG.info("Goto non-compliant list");
-                waitForPageToLoad(GUI_NONCOMPLIANT_URL, driver);   
-                driver.findElement(By.linkText(GUI_DOWNLOAD_LINKTEXT)).click(); 
-                String newfile = pollAndRename(NONCOMPLIANT_FILE_PREFIX, NihmsStatus.NON_COMPLIANT);
-                LOG.info("Downloaded and saved non-compliant publications as file " + newfile);       
-                Thread.sleep(2000);       
-            }
-            
-            if (statusesToDownload.contains(NihmsStatus.IN_PROCESS)) {
-                driver.findElement(By.xpath(GUI_INPROCESS_LINK_XPATH)).click();     
-                LOG.info("Goto in-process list");
-                waitForPageToLoad(GUI_INPROGRESS_URL, driver);  
-                driver.findElement(By.linkText(GUI_DOWNLOAD_LINKTEXT)).click();  
-                String newfile = pollAndRename(INPROCESS_FILE_PREFIX, NihmsStatus.IN_PROCESS);
-                LOG.info("Downloaded and saved in-process publications as file " + newfile);  
-                Thread.sleep(2000);        
+                params.put("pdf", startDate);
             }
 
-            //logout
-            driver.get(GUI_SIGNOUT_LINK); 
-            
+            if (statusesToDownload.contains(NihmsStatus.COMPLIANT)) {
+                LOG.info("Goto {} list", NihmsStatus.COMPLIANT);
+                File file = newFile(NihmsStatus.COMPLIANT);
+                URL url = urlBuilder.compliantUrl(params);
+
+                download(url, file, NihmsStatus.COMPLIANT);
+            }
+
+            if (statusesToDownload.contains(NihmsStatus.NON_COMPLIANT)) {
+                LOG.info("Goto {} list", NihmsStatus.NON_COMPLIANT);
+                File file = newFile(NihmsStatus.NON_COMPLIANT);
+                URL url = urlBuilder.nonCompliantUrl(params);
+                download(url, file, NihmsStatus.NON_COMPLIANT);
+            }
+
+            if (statusesToDownload.contains(NihmsStatus.IN_PROCESS)) {
+                LOG.info("Goto {} list", NihmsStatus.IN_PROCESS);
+                File file = newFile(NihmsStatus.IN_PROCESS);
+                URL url = urlBuilder.inProcessUrl(params);
+                download(url, file, NihmsStatus.IN_PROCESS);
+            }
+
         } catch (Exception ex) {
             throw new RuntimeException("An error occurred while downloading the NIHMS files.", ex);
-        } finally {
-            try {
-                if (driver!=null) {
-                    driver.quit();
-                } 
-            } catch (Exception ex) {
-                LOG.warn("Could not quit driver. Webdriver may still be running and require manual cleanup.");
-            }
-            try {
-                String path = new File(NihmsHarvesterConfig.getGeckoDriverPath()).getName();
-                Runtime.getRuntime().exec("taskkill /F /IM " + path + " /T");
-            } catch (Exception ex) {
-                LOG.warn("Could not clean up geckodriver task. Webdriver may still be running and require manual cleanup.");
-            }
         }
     }
-    
+
+    private void download(URL url, File outputFile, NihmsStatus status) throws IOException, InterruptedException {
+        LOG.debug("Retrieving: {}", url);
+        try (Response res = okHttp
+                .newCall(new Request.Builder()
+                        .get()
+                        .url(url)
+                        .build())
+                .execute();
+             FileOutputStream out = new FileOutputStream(outputFile)) {
+
+            if (!res.isSuccessful()) {
+                throw new RuntimeException(String.format("Error retrieving %s (HTTP status: %s): %s",
+                        url, res.code(), res.message()));
+            }
+
+            IOUtils.copy(res.body().byteStream(), out);
+            LOG.info("Downloaded and saved {} publications as file {}", status, outputFile);
+            Thread.sleep(2000);
+        }
+    }
+
     /**
      * null or empty are OK for start date, but a badly formatted date that does not have the format mm-yyyy should return false
      * @param startDate true if valid start date (empty or formatted mm-yyyy)
@@ -250,44 +163,12 @@ public class NihmsHarvester {
     public static boolean validStartDate(String startDate) {
         return (nullOrEmpty(startDate) || startDate.matches("^(0?[1-9]|1[012])-(\\d{4})$"));
     }
-    
-    /**
-     * Waits for page to load, checks URL matches expected URL. Throws error if times out
-     * @param loadingUrl the url
-     * @param driver the driver
-     * @throws InterruptedException if the current thread is interrupted
-     */
-    private void waitForPageToLoad(String loadingUrl, WebDriver driver) throws InterruptedException {
-        long start_time = System.currentTimeMillis();
-        long wait_time = 60000;
-        long end_time = start_time + wait_time;
 
-        while (!driver.getCurrentUrl().startsWith(loadingUrl) &&
-                System.currentTimeMillis() < end_time) {
-            LOG.info("Waiting for page to load...");
-            Thread.sleep(3000);     
-        }
-        
-        if (!driver.getCurrentUrl().startsWith(loadingUrl)) {
-            throw new RuntimeException("Page load timed out after one minute. Try again later.");
-        }
-        
-    }
-    
-    
-    private String pollAndRename(String prefix, NihmsStatus status) throws InterruptedException {
-        File newfile = FileWatcher.getNewFile(downloadDirectoryPath, prefix, ".csv");
-        LOG.info("New file downloaded: " + newfile.getAbsolutePath());
-        String newFilePath = null;
-        if (newfile!=null) {
-            Thread.sleep(2000);     
-            DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyyMMddHHmmss");
-            String timeStamp = fmt.print(new DateTime());
-            newFilePath = downloadDirectoryPath.toString() + "/" + status.toString() + "_nihmspubs_" + timeStamp + ".csv";
-            newfile.renameTo(new File(newFilePath));            
-        } 
-        LOG.info("Downloaded {} publications as file {}", status.toString(), newFilePath);       
-        return newFilePath;
+    private File newFile(NihmsStatus status) {
+        DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyyMMddHHmmss");
+        String timeStamp = fmt.print(new DateTime());
+        String newFilePath = downloadDirectoryPath.toString() + "/" + status.toString() + "_nihmspubs_" + timeStamp + ".csv";
+        return new File(newFilePath);
     }
 
 }

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvester.java
@@ -94,7 +94,7 @@ public class NihmsHarvester {
             throw new RuntimeException("statusesToDownload list cannot be empty");
         }
         if (!validStartDate(startDate)) {
-            throw new RuntimeException(String.format("The startDate %s is not valid. The date must be formatted as yyyy-mm", startDate));
+            throw new RuntimeException(String.format("The startDate %s is not valid. The date must be formatted as mm-yyyy", startDate));
         }
 
         try {

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfig.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfig.java
@@ -26,25 +26,27 @@ import java.util.Map;
  */
 public class NihmsHarvesterConfig {
 
-    private static final String API_HOST_KEY = "nihmsetl.api.host";
+    public static final String NIHMS_ETL_PROPERTY_PREFIX = "nihmsetl.";
 
-    private static final String DEFAULT_API_HOST = "www.nci.nlm.nih.gov";
+    private static final String API_HOST_KEY = NIHMS_ETL_PROPERTY_PREFIX + "api.host";
 
-    private static final String API_SCHEME_KEY = "nihmsetl.api.scheme";
+    private static final String DEFAULT_API_HOST = "www.ncbi.nlm.nih.gov";
+
+    private static final String API_SCHEME_KEY = NIHMS_ETL_PROPERTY_PREFIX + "api.scheme";
 
     private static final String DEFAULT_API_SCHEME = "https";
 
-    private static final String API_PATH_KEY = "nihmsetl.api.path";
+    private static final String API_PATH_KEY = NIHMS_ETL_PROPERTY_PREFIX + "api.path";
 
     private static final String DEFAULT_API_PATH = "/pmc/utils/pacm/";
 
-    static final String API_URL_PARAM_PREFIX = "nihmsetl.api.url.param.";
+    static final String API_URL_PARAM_PREFIX = NIHMS_ETL_PROPERTY_PREFIX + "api.url.param.";
 
-    private static final String HTTP_READ_TIMEOUT_KEY = "nihmsetl.http.read-timeout-ms";
+    private static final String HTTP_READ_TIMEOUT_KEY = NIHMS_ETL_PROPERTY_PREFIX + "http.read-timeout-ms";
 
     private static final String DEFAULT_HTTP_READ_TIMEOUT = "10000";
 
-    private static final String HTTP_CONNECT_TIMEOUT_KEY = "nihmsetl.http.connect-timeout-ms";
+    private static final String HTTP_CONNECT_TIMEOUT_KEY = NIHMS_ETL_PROPERTY_PREFIX + "http.connect-timeout-ms";
 
     private static final String DEFAULT_HTTP_CONNECT_TIMEOUT = "10000";
 
@@ -68,5 +70,13 @@ public class NihmsHarvesterConfig {
                 .collect(HashMap::new,
                         (map, entry) -> map.put(((String)entry.getKey()).substring(API_URL_PARAM_PREFIX.length()), (String)entry.getValue()),
                         (map1, map2) -> map2.putAll(map1));
+    }
+
+    public static long getHttpConnectTimeoutMs() {
+        return Long.valueOf(ConfigUtil.getSystemProperty(HTTP_CONNECT_TIMEOUT_KEY, DEFAULT_HTTP_CONNECT_TIMEOUT));
+    }
+
+    public static long getHttpReadTimeoutMs() {
+        return Long.valueOf(ConfigUtil.getSystemProperty(HTTP_READ_TIMEOUT_KEY, DEFAULT_HTTP_READ_TIMEOUT));
     }
 }

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfig.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfig.java
@@ -16,7 +16,9 @@
 package org.dataconservancy.pass.loader.nihms;
 
 import org.dataconservancy.pass.loader.nihms.util.ConfigUtil;
-import org.dataconservancy.pass.loader.nihms.util.FileUtil;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Holds information and methods required to configure the NIHMS harvester tool.
@@ -24,38 +26,47 @@ import org.dataconservancy.pass.loader.nihms.util.FileUtil;
  */
 public class NihmsHarvesterConfig {
 
-    private static final String USERNAME_KEY = "nihmsetl.harvester.username";
-    
-    private static final String PASSWRD_KEY = "nihmsetl.harvester.password";
-    
-    private static final String GECKO_PATH_KEY = "webdriver.gecko.driver";
-    
-    private static final String GECKODRIVER_DEFAULTNAME = "geckodriver.exe";
-    
-    /**
-     * Retrieve the user name from a system property, or use default
-     * @return user name
-     */
-    public static String getUserName() {
-        String username = ConfigUtil.getSystemProperty(USERNAME_KEY, null);
-        return username;
+    private static final String API_HOST_KEY = "nihmsetl.api.host";
+
+    private static final String DEFAULT_API_HOST = "www.nci.nlm.nih.gov";
+
+    private static final String API_SCHEME_KEY = "nihmsetl.api.scheme";
+
+    private static final String DEFAULT_API_SCHEME = "https";
+
+    private static final String API_PATH_KEY = "nihmsetl.api.path";
+
+    private static final String DEFAULT_API_PATH = "/pmc/utils/pacm/";
+
+    static final String API_URL_PARAM_PREFIX = "nihmsetl.api.url.param.";
+
+    private static final String HTTP_READ_TIMEOUT_KEY = "nihmsetl.http.read-timeout-ms";
+
+    private static final String DEFAULT_HTTP_READ_TIMEOUT = "10000";
+
+    private static final String HTTP_CONNECT_TIMEOUT_KEY = "nihmsetl.http.connect-timeout-ms";
+
+    private static final String DEFAULT_HTTP_CONNECT_TIMEOUT = "10000";
+
+    public static String getApiHost() {
+        return ConfigUtil.getSystemProperty(API_HOST_KEY, DEFAULT_API_HOST);
     }
 
-    /**
-     * Retrieve the password from a system property, or use default
-     * @return user name
-     */
-    public static String getPassword() {
-        String password = ConfigUtil.getSystemProperty(PASSWRD_KEY, null);
-        return password;
+    public static String getApiScheme() {
+        return ConfigUtil.getSystemProperty(API_SCHEME_KEY, DEFAULT_API_SCHEME);
     }
 
-    /**
-     * Retrieve the gecko driver path from a system property, or use current directory
-     * @return user name
-     */
-    public static String getGeckoDriverPath() {
-        String geckoDriverPath = ConfigUtil.getSystemProperty(GECKO_PATH_KEY, FileUtil.getCurrentDirectory() + "/" + GECKODRIVER_DEFAULTNAME);
-        return geckoDriverPath;
+    public static String getApiPath() {
+        return ConfigUtil.getSystemProperty(API_PATH_KEY, DEFAULT_API_PATH);
+    }
+
+    public static Map<String, String> getApiUrlParams() {
+        return System.getProperties()
+                .entrySet()
+                .stream()
+                .filter((entry) -> ((String)entry.getKey()).startsWith(API_URL_PARAM_PREFIX))
+                .collect(HashMap::new,
+                        (map, entry) -> map.put(((String)entry.getKey()).substring(API_URL_PARAM_PREFIX.length()), (String)entry.getValue()),
+                        (map1, map2) -> map2.putAll(map1));
     }
 }

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/UrlBuilder.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/UrlBuilder.java
@@ -1,0 +1,73 @@
+/*
+ *
+ *  * Copyright 2019 Johns Hopkins University
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.dataconservancy.pass.loader.nihms;
+
+import com.damnhandy.uri.template.UriTemplate;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+public class UrlBuilder {
+
+    private static final String TEMPLATE = "{scheme}://{host}{+path}{+type}{?params*}";
+
+    public URL compliantUrl() {
+        return urlFor(UrlType.COMPLIANT, Collections.emptyMap());
+    }
+
+    public URL compliantUrl(Map<String, String> params) {
+        return urlFor(UrlType.COMPLIANT, params);
+    }
+
+    public URL nonCompliantUrl() {
+        return urlFor(UrlType.NON_COMPLIANT, Collections.emptyMap());
+    }
+
+    public URL nonCompliantUrl(Map<String, String> params) {
+        return urlFor(UrlType.NON_COMPLIANT, params);
+    }
+
+    public URL inProcessUrl() {
+        return urlFor(UrlType.IN_PROCESS, Collections.emptyMap());
+    }
+
+    public URL inProcessUrl(Map<String, String> params) {
+        return urlFor(UrlType.IN_PROCESS, params);
+    }
+
+    private URL urlFor(UrlType type, Map<String, String> params) {
+        try {
+            Map<String, String> mergedParams = NihmsHarvesterConfig.getApiUrlParams();
+            mergedParams.putAll(params);
+
+            return new URL(UriTemplate.fromTemplate(TEMPLATE)
+                    .set("scheme", NihmsHarvesterConfig.getApiScheme())
+                    .set("host", NihmsHarvesterConfig.getApiHost())
+                    .set("path", NihmsHarvesterConfig.getApiPath())
+                    .set("type", type.getCode())
+                    .set("params", mergedParams)
+                    .expand());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+}

--- a/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/UrlType.java
+++ b/nihms-data-harvest/src/main/java/org/dataconservancy/pass/loader/nihms/UrlType.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright 2019 Johns Hopkins University
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.dataconservancy.pass.loader.nihms;
+
+public enum UrlType {
+
+    COMPLIANT("c"),
+    NON_COMPLIANT("n"),
+    IN_PROCESS("p");
+
+    private String code;
+
+    UrlType(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfigTest.java
+++ b/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  * Copyright 2019 Johns Hopkins University
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.dataconservancy.pass.loader.nihms;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class NihmsHarvesterConfigTest {
+
+    /**
+     * Insures that the {@link NihmsHarvesterConfig#getApiUrlParams()} properly processes the system properties prefixed by {@code nihmsetl.api.url.param.}
+     */
+    @Test
+    public void urlParameters() {
+        Map<String, String> expectedParams = new HashMap<String, String>() {
+            {
+                put("param1", "value1");
+                put("param2", "value2");
+                put("param3", "value3");
+            }
+        };
+
+        expectedParams.forEach((key, value) -> {
+            key = NihmsHarvesterConfig.API_URL_PARAM_PREFIX + key;
+            System.setProperty(key, value);
+        });
+
+        Map<String, String> actualParams = NihmsHarvesterConfig.getApiUrlParams();
+
+        assertEquals(expectedParams, actualParams);
+    }
+}

--- a/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfigTest.java
+++ b/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/NihmsHarvesterConfigTest.java
@@ -18,14 +18,27 @@
 
 package org.dataconservancy.pass.loader.nihms;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.dataconservancy.pass.loader.nihms.NihmsHarvesterConfig.API_URL_PARAM_PREFIX;
 import static org.junit.Assert.*;
 
 public class NihmsHarvesterConfigTest {
+
+    @AfterClass
+    public static void cleanUpSystemProps() {
+        System.getProperties()
+                .entrySet()
+                .stream()
+                .filter((entry) -> ((String)entry.getKey()).startsWith(API_URL_PARAM_PREFIX))
+                .collect(Collectors.toSet())
+                .forEach(entry -> System.clearProperty((String)entry.getKey()));
+    }
 
     /**
      * Insures that the {@link NihmsHarvesterConfig#getApiUrlParams()} properly processes the system properties prefixed by {@code nihmsetl.api.url.param.}

--- a/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/UrlBuilderTest.java
+++ b/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/UrlBuilderTest.java
@@ -1,0 +1,239 @@
+/*
+ *
+ *  * Copyright 2019 Johns Hopkins University
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.dataconservancy.pass.loader.nihms;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static org.junit.Assert.*;
+
+public class UrlBuilderTest {
+
+    private UrlBuilder underTest;
+
+    private URL generatedUrl;
+
+    private Map<String, String> overrides = Collections.emptyMap();
+
+    private Map<String, String> additional = Collections.emptyMap();
+
+    @BeforeClass
+    public static void apiParams() throws Exception {
+        /*
+        nihmsetl.api.url.param.filter =
+        nihmsetl.api.url.param.format = csv
+        nihmsetl.api.url.param.inst = JOHNS HOPKINS
+        nihmsetl.api.url.param.ipf = 4134401
+        nihmsetl.api.url.param.rd = 07/02/2019
+        nihmsetl.api.url.param.pdf = 07/2018
+        nihmsetl.api.url.param.pdt = 07/2019
+         */
+
+        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "filter"), "");
+        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "format"), "csv");
+        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "inst"), "JOHNS HOPKINS");
+        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "ipf"), "4134401");
+        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "rd"), "07/02/2019");
+        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "pdf"), "07/2018");
+        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "pdt"), "07/2019");
+
+        assertEquals("", NihmsHarvesterConfig.getApiUrlParams().get("filter"));
+        assertEquals("csv", NihmsHarvesterConfig.getApiUrlParams().get("format"));
+        assertEquals("JOHNS HOPKINS", NihmsHarvesterConfig.getApiUrlParams().get("inst"));
+        assertEquals("4134401", NihmsHarvesterConfig.getApiUrlParams().get("ipf"));
+        assertEquals("07/02/2019", NihmsHarvesterConfig.getApiUrlParams().get("rd"));
+        assertEquals("07/2018", NihmsHarvesterConfig.getApiUrlParams().get("pdf"));
+        assertEquals("07/2019", NihmsHarvesterConfig.getApiUrlParams().get("pdt"));
+    }
+
+    @Before
+    public void setUp() {
+        underTest = new UrlBuilder();
+    }
+
+    @After
+    public void verifyScheme() {
+        assertEquals(NihmsHarvesterConfig.getApiScheme(), generatedUrl.getProtocol());
+    }
+
+    @After
+    public void verifyHost() {
+        assertEquals(NihmsHarvesterConfig.getApiHost(), generatedUrl.getHost());
+    }
+
+    @After
+    public void verifyPath() throws Exception {
+        assertTrue(generatedUrl.getPath().startsWith(NihmsHarvesterConfig.getApiPath()));
+    }
+
+    @After
+    public void verifyParams() throws URISyntaxException {
+        String query = generatedUrl.toURI().getQuery(); // .toURI() will decode the query parameter values
+        assertNotNull(query);
+        String[] parts = query.split("&");
+        assertEquals(format("Unexpected number of URL parameters.  Wanted %s, got %s", additional.size() + 7, parts.length),
+                additional.size() + 7, parts.length);
+
+        Stream.of(parts).forEach(part -> {
+            String[] subpart = part.split("=");
+            String param = subpart[0];
+            String value = subpart.length > 1 ? subpart[1] : null;
+
+            switch (param) {
+                case "format":
+                    assertEquals(overrides.getOrDefault("format", "csv"), value);
+                    break;
+                case "filter":
+                    assertEquals(overrides.getOrDefault("filter", null), value);
+                    break;
+                case "inst":
+                    assertEquals(overrides.getOrDefault("inst", "JOHNS HOPKINS"), value);
+                    break;
+                case "ipf":
+                    assertEquals(overrides.getOrDefault("ipf", "4134401"), value);
+                    break;
+                case "rd":
+                    assertEquals(overrides.getOrDefault("rd", "07/02/2019"), value);
+                    break;
+                case "pdf":
+                    assertEquals(overrides.getOrDefault("pdf", "07/2018"), value);
+                    break;
+                case "pdt":
+                    assertEquals(overrides.getOrDefault("pdt", "07/2019"), value);
+                    break;
+                default:
+                    if (additional.containsKey(param)) {
+                        assertEquals(additional.get(param), value);
+                    } else {
+                        throw new RuntimeException("Unknown URL parameter '" + param + "' with value '" + value + "'");
+                    }
+            }
+        });
+
+
+    }
+
+
+
+    @After
+    public void tearDown() throws Exception {
+        System.err.println(generatedUrl.toString());
+    }
+
+    @Test
+    public void compliantUrl() {
+        generatedUrl = underTest.compliantUrl();
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.COMPLIANT.getCode())));
+    }
+
+    @Test
+    public void inProcessUrl() {
+        generatedUrl = underTest.inProcessUrl();
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.IN_PROCESS.getCode())));
+    }
+
+    @Test
+    public void nonCompliantUrl() {
+        generatedUrl = underTest.nonCompliantUrl();
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.NON_COMPLIANT.getCode())));
+    }
+
+    @Test
+    public void compliantUrlWithParamOverride() {
+        overrides = new HashMap<String, String>() {
+            {
+                put("format", "moo");
+            }
+        };
+
+        generatedUrl = underTest.compliantUrl(overrides);
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.COMPLIANT.getCode())));
+    }
+
+    @Test
+    public void compliantUrlWithAdditionalParam() {
+        additional = new HashMap<String, String>() {
+            {
+                put("api-key", "api-key-value");
+            }
+        };
+
+        generatedUrl = underTest.compliantUrl(additional);
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.COMPLIANT.getCode())));
+    }
+
+    @Test
+    public void nonCompliantUrlWithParamOverride() {
+        overrides = new HashMap<String, String>() {
+            {
+                put("format", "moo");
+            }
+        };
+
+        generatedUrl = underTest.nonCompliantUrl(overrides);
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.NON_COMPLIANT.getCode())));
+    }
+
+    @Test
+    public void nonCompliantUrlWithAdditionalParam() {
+        additional = new HashMap<String, String>() {
+            {
+                put("api-key", "api-key-value");
+            }
+        };
+
+        generatedUrl = underTest.nonCompliantUrl(additional);
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.NON_COMPLIANT.getCode())));
+    }
+
+    @Test
+    public void inProcessUrlWithParamOverride() {
+        overrides = new HashMap<String, String>() {
+            {
+                put("format", "moo");
+            }
+        };
+
+        generatedUrl = underTest.inProcessUrl(overrides);
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.IN_PROCESS.getCode())));
+    }
+
+    @Test
+    public void inProcessUrlWithAdditionalParam() {
+        additional = new HashMap<String, String>() {
+            {
+                put("api-key", "api-key-value");
+            }
+        };
+
+        generatedUrl = underTest.inProcessUrl(additional);
+        assertTrue(generatedUrl.getPath().endsWith(format("/%s", UrlType.IN_PROCESS.getCode())));
+    }
+}

--- a/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/UrlBuilderTest.java
+++ b/nihms-data-harvest/src/test/java/org/dataconservancy/pass/loader/nihms/UrlBuilderTest.java
@@ -19,6 +19,7 @@
 package org.dataconservancy.pass.loader.nihms;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,10 +29,12 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static org.dataconservancy.pass.loader.nihms.NihmsHarvesterConfig.API_URL_PARAM_PREFIX;
 import static org.junit.Assert.*;
 
 public class UrlBuilderTest {
@@ -56,13 +59,13 @@ public class UrlBuilderTest {
         nihmsetl.api.url.param.pdt = 07/2019
          */
 
-        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "filter"), "");
-        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "format"), "csv");
-        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "inst"), "JOHNS HOPKINS");
-        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "ipf"), "4134401");
-        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "rd"), "07/02/2019");
-        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "pdf"), "07/2018");
-        System.setProperty(join("", NihmsHarvesterConfig.API_URL_PARAM_PREFIX, "pdt"), "07/2019");
+        System.setProperty(join("", API_URL_PARAM_PREFIX, "filter"), "");
+        System.setProperty(join("", API_URL_PARAM_PREFIX, "format"), "csv");
+        System.setProperty(join("", API_URL_PARAM_PREFIX, "inst"), "JOHNS HOPKINS");
+        System.setProperty(join("", API_URL_PARAM_PREFIX, "ipf"), "4134401");
+        System.setProperty(join("", API_URL_PARAM_PREFIX, "rd"), "07/02/2019");
+        System.setProperty(join("", API_URL_PARAM_PREFIX, "pdf"), "07/2018");
+        System.setProperty(join("", API_URL_PARAM_PREFIX, "pdt"), "07/2019");
 
         assertEquals("", NihmsHarvesterConfig.getApiUrlParams().get("filter"));
         assertEquals("csv", NihmsHarvesterConfig.getApiUrlParams().get("format"));
@@ -71,6 +74,16 @@ public class UrlBuilderTest {
         assertEquals("07/02/2019", NihmsHarvesterConfig.getApiUrlParams().get("rd"));
         assertEquals("07/2018", NihmsHarvesterConfig.getApiUrlParams().get("pdf"));
         assertEquals("07/2019", NihmsHarvesterConfig.getApiUrlParams().get("pdt"));
+    }
+
+    @AfterClass
+    public static void cleanUpSystemProps() {
+        System.getProperties()
+                .entrySet()
+                .stream()
+                .filter((entry) -> ((String)entry.getKey()).startsWith(API_URL_PARAM_PREFIX))
+                .collect(Collectors.toSet())
+                .forEach(entry -> System.clearProperty((String)entry.getKey()));
     }
 
     @Before
@@ -136,11 +149,7 @@ public class UrlBuilderTest {
                     }
             }
         });
-
-
     }
-
-
 
     @After
     public void tearDown() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
     <selenium.version>3.11.0</selenium.version>
     <args4j.version>2.33</args4j.version>
     <mockito.version>1.9.5</mockito.version>
+    <handy-uri-templates.version>2.1.8</handy-uri-templates.version>
+    <commons-io.version>2.6</commons-io.version>
   </properties>
   
   <modules>
@@ -358,7 +360,19 @@
         <version>${logback.version}</version>
         <scope>test</scope>
       </dependency>
-      
+
+      <dependency>
+        <groupId>com.damnhandy</groupId>
+        <artifactId>handy-uri-templates</artifactId>
+        <version>${handy-uri-templates.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
     <mockito.version>1.9.5</mockito.version>
     <handy-uri-templates.version>2.1.8</handy-uri-templates.version>
     <commons-io.version>2.6</commons-io.version>
+    <okhttp.version>3.14.1</okhttp.version>
   </properties>
   
   <modules>
@@ -321,18 +322,6 @@
         <artifactId>commons-csv</artifactId>
         <version>${commons-csv.version}</version>
      </dependency>
-    
-      <dependency>
-        <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>selenium-firefox-driver</artifactId>
-        <version>${selenium.version}</version>
-      </dependency>
-    
-      <dependency>
-        <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>selenium-java</artifactId>
-        <version>${selenium.version}</version>
-      </dependency>
       
       <dependency>
         <groupId>args4j</groupId>
@@ -365,6 +354,12 @@
         <groupId>com.damnhandy</groupId>
         <artifactId>handy-uri-templates</artifactId>
         <version>${handy-uri-templates.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Harvest NIH PACM data using NIH API

Updates the harvester to use the NIH API to retrieve PACM data, replacing the use of Selenium mimicking a human user interaction with the NIH PACM website.

Links used to retrieve the compliant, non-compliant, and in-process PACM CSV files look like:
- `https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/p?format=csv&grant=&inst=JOHNS+HOPKINS+UNIVERSITY&ipf=4134401&pdf=07%2F2018&pdt=07%2F2019&rd=`

This PR uses a [URI template](https://tools.ietf.org/html/rfc6570) to generate links to each type (one of compliant, non-compliant, and in-process) of CSV file: `{scheme}://{host}{+path}{+type}{?params*}`

The template is parameterized by properties supplied in the `nihms-harvest.properties` configuration file:
- `nihmsetl.api.host`
- `nihmsetl.api.scheme`
- `nihmsetl.api.path`
- `nihmsetl.api.url.param.filter`
- `nihmsetl.api.url.param.format`
- `nihmsetl.api.url.param.inst`
- `nihmsetl.api.url.param.ipf`
- `nihmsetl.api.url.param.rd`
- `nihmsetl.api.url.param.pdf`
- `nihmsetl.api.url.param.pdt`
- `nihmsetl.api.url.param.api-token`

The template is also parameterized by command line options or flags.  The `-startDate` option will be used to parameterize the URL template with a start date.  The status flags (`-noncompliant`, `-inprocess`, `-compliant`) are also used to parameterize the template.

If the parameters need to be changed or added, simply add a property to `nihms-harvest.properties` named `nihmsetl.api.url.param.<param name>`, where `<param name>` is the URL request parameter to use.

If requests time out, the following properties can be provided:
- `nihmsetl.http.read-timeout-ms`
- `nihmsetl.http.connect-timeout-ms`

Closes #42 