### PR TITLE
Upgrade log4j-to-slf4j and log4j-api to 2.15.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <org-json.version>20180130</org-json.version>
     <commons-csv.version>1.5</commons-csv.version>
     <slf4j.version>1.7.25</slf4j.version>
+    <log4j.version>2.15.0</log4j.version>
     <pass-client.version>0.8.0</pass-client.version>
     <logback.version>1.2.3</logback.version>
     <selenium.version>3.11.0</selenium.version>
@@ -296,6 +297,18 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>${log4j.version}</version>
       </dependency>
       
       <dependency>


### PR DESCRIPTION
I haven't clarified the exposure of SL4J to the log4j RCE vulnerability, but this is a simple fix to insure use of log4j 2.15.0.